### PR TITLE
Fixing operation rendering

### DIFF
--- a/src/components/APIDoc/ApiDoc.tsx
+++ b/src/components/APIDoc/ApiDoc.tsx
@@ -37,17 +37,11 @@ export const ApiDoc: React.FunctionComponent<ApiDocProps> = props => {
             </StackItem>
         )}
         { Object.entries(openapi.paths).map(([path, pathObject]) => {
-            const operations = Object.entries(
+            return Object.entries(
                 // Looks like openapi v3.1 supports components here as well
                 pathObject as Record<OpenAPIV3.HttpMethods, OpenAPIV3.OperationObject>
-            )
-
-            let commonParams: [string, object] | undefined;
-            commonParams = operations.find(operationInfo => operationInfo[0] === "parameters")
-
-            console.log("commonParams...", commonParams)
-            return operations.map(([verb, operation]) =>
-                operationVerbs.includes(verb) && <StackItem key={`${verb} ${path}`}>
+            ).map(([verb, operation]) => operationVerbs.includes(verb) &&
+                <StackItem key={`${verb} ${path}`}>
                     <Operation verb={ verb } path={ path } operation={ operation } document={ openapi }/>
                 </StackItem>
             );

--- a/src/components/APIDoc/ApiDoc.tsx
+++ b/src/components/APIDoc/ApiDoc.tsx
@@ -10,6 +10,8 @@ interface ApiDocProps {
     openapi: OpenAPIV3.Document;
 }
 
+const operationVerbs: string[] = ["get", "post", "patch", "put", "delete"]
+
 export const ApiDoc: React.FunctionComponent<ApiDocProps> = props => {
     const { openapi } = props;
 
@@ -35,11 +37,17 @@ export const ApiDoc: React.FunctionComponent<ApiDocProps> = props => {
             </StackItem>
         )}
         { Object.entries(openapi.paths).map(([path, pathObject]) => {
-            return Object.entries(
+            const operations = Object.entries(
                 // Looks like openapi v3.1 supports components here as well
                 pathObject as Record<OpenAPIV3.HttpMethods, OpenAPIV3.OperationObject>
-            ).map(([verb, operation]) =>
-                <StackItem key={`${verb} ${path}`}>
+            )
+
+            let commonParams: [string, object] | undefined;
+            commonParams = operations.find(operationInfo => operationInfo[0] === "parameters")
+
+            console.log("commonParams...", commonParams)
+            return operations.map(([verb, operation]) =>
+                operationVerbs.includes(verb) && <StackItem key={`${verb} ${path}`}>
                     <Operation verb={ verb } path={ path } operation={ operation } document={ openapi }/>
                 </StackItem>
             );

--- a/src/components/APIDoc/ApiDoc.tsx
+++ b/src/components/APIDoc/ApiDoc.tsx
@@ -10,7 +10,7 @@ interface ApiDocProps {
     openapi: OpenAPIV3.Document;
 }
 
-const operationVerbs: string[] = ["get", "post", "patch", "put", "delete"]
+const operationVerbs: string[] = ["get", "post", "patch", "put", "delete", "options", "head", "trace"]
 
 export const ApiDoc: React.FunctionComponent<ApiDocProps> = props => {
     const { openapi } = props;


### PR DESCRIPTION
OpenAPI path objects may contain verbs that are not HTTP methods (`["get", "post", "patch", "put", "delete"]`).
Sometimes, path object may even contain a global `parameters` that are common in all methods of a particular path. cc System Baseline spec.


> _Whenever we have a common parameters section, we should not render it as an operation but rather pass it down to the HTTP methods._

^ we will do this later