### PR TITLE
Changing the name of the application to API Documentation and Guides

### DIFF
--- a/src/pages/APIPage.tsx
+++ b/src/pages/APIPage.tsx
@@ -26,7 +26,7 @@ export const APIPage: FunctionComponent = () => {
                 <BreadcrumbItem to='#' onClick={(event) => {
                     event.preventDefault();
                     navigate('/');
-                }} >API Catalog</BreadcrumbItem>
+                }} >API Documentation and Guides</BreadcrumbItem>
                 <BreadcrumbItem isActive>{api}</BreadcrumbItem>
             </Breadcrumb>
         </PageSection>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -27,7 +27,7 @@ export const LandingPage: FunctionComponent = () => {
       <PageGroup stickyOnBreakpoint={{ default: 'top' }}>
         <PageSection variant={PageSectionVariants.darker} className="pf-u-px-2xl-on-md pf-u-pb-2xl pf-u-background-color-dark-100">
           <TextContent>
-            <Text component={TextVariants.h1}>The Red Hat API Catalog</Text>
+            <Text component={TextVariants.h1}>The Red Hat API Documentation and Guides</Text>
             <Text component={TextVariants.p}>
               Here you'll find APIs for many Red Hat products and services.
               Check back regularly as we're adding new ones all the time.


### PR DESCRIPTION
Changing the name of the APP from "API catalog" to "API Documentation and Guides".