### PR TITLE
cleanup operation styling, etc

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,25 +1,38 @@
-.pf-c-card__body {
-  svg {
-    width: 38px;
-    height: 38px;
+//remove before migrating to developers.redhat.com
+ .apid-c-page-landingpage, .apid-c-page-apipage {
+   max-width: 1450px;
+   margin: auto;
+ }
+
+.apid-c-page-landingpage {
+  .pf-c-card__body {
+    svg {
+      width: 38px;
+      height: 38px;
+    }
   }
 }
 
-
-//remove before migrating to developers.redhat.com
-.apid-c-page-landingpage, .apid-c-page-apipage {
-  max-width: 1450px;
-  margin: auto;
+.apid-c-sidebar {
+  .pf-c-text-input-group {
+    width: 250px;
+  }
+  .pf-c-text-input-group__icon {
+    display: none;
+  }
+  .pf-c-text-input-group__text-input {
+    padding-left: 8px;
+  }
 }
 
 .apid-c-card-codeblock {
   .pf-c-card__header {
     background-color: var(--pf-global--BackgroundColor--dark-200);
-    border-radius: 30px 30px 0 0;
+    border-radius: 16px 16px 0 0;
   }
   .pf-c-card__footer {
     background-color: var(--pf-global--BackgroundColor--dark-100);
-    border-radius: 0 0 30px 30px;
+    border-radius: 0 0 16px 16px;
   }
   .pf-c-dropdown {
     --pf-c-dropdown__toggle--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);

--- a/src/components/APIDoc/CodeSamples.tsx
+++ b/src/components/APIDoc/CodeSamples.tsx
@@ -61,10 +61,9 @@ export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({parameter
     };
 
     return <>
-      <Card className="apid-c-card-codeblock pf-u-my-xl" isPlain>
+      <Card className="apid-c-card-codeblock" isPlain>
         <CardHeader className="pf-u-p-0 pf-u-pr-md pf-u-color-light-100">
           <FlexItem className="pf-u-flex-grow-1 pf-u-pl-lg">
-            {verb} {path}
           </FlexItem>
           <FlexItem align={{ default: 'alignRight' }}>
             <CodeBlockDropdown setTemplate={setTemplate} setLanguage={setLanguage}/>

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -1,99 +1,99 @@
 import React from 'react';
 import {OpenAPIV3} from "openapi-types";
 import {buildExample, deRef} from "../../utils/Openapi";
-import {Stack, StackItem, Flex, FlexItem, Text, TextContent, TextVariants} from "@patternfly/react-core";
+import {Stack, StackItem, Grid, GridItem, Text, TextContent, TextVariants} from "@patternfly/react-core";
 import {TableComposable, Tbody, Td, Thead, Tr} from "@patternfly/react-table";
 import {ExampleResponse} from "./ExampleResponse";
 import {CodeSamples} from "./CodeSamples";
 
 export interface OperationProps {
-    verb: string;
-    path: string;
-    operation: OpenAPIV3.OperationObject;
-    document: OpenAPIV3.Document;
+  verb: string;
+  path: string;
+  operation: OpenAPIV3.OperationObject;
+  document: OpenAPIV3.Document;
 }
 export const Operation: React.FunctionComponent<OperationProps> = ({verb, path, operation, document}) => {
-    const parameters = (operation.parameters || []).map(p => deRef(p, document));
-    const responseMap = Object.entries(operation.responses ?? {});
-    const responseExample = React.useMemo(() => {
-        if (operation.responses) {
-            const example = buildExample(operation.responses, document);
-            if (example) {
-                return JSON.stringify(example, undefined, 2);
-            }
-        }
+  const parameters = (operation.parameters || []).map(p => deRef(p, document));
+  const responseMap = Object.entries(operation.responses ?? {});
+  const responseExample = React.useMemo(() => {
+    if (operation.responses) {
+      const example = buildExample(operation.responses, document);
+      if (example) {
+          return JSON.stringify(example, undefined, 2);
+      }
+    }
 
-        return undefined;
-    }, [ operation.responses, document]);
+      return undefined;
+  }, [ operation.responses, document]);
 
-    return <Flex justifyContent={{ default: "justifyContentSpaceBetween"}}>
-                <FlexItem flex={{default: 'flex_2'}} spacer={{default: "spacer3xl"}}>
-                    <Stack hasGutter>
-                        <StackItem>
-                            <TextContent>
-                                <Text component={TextVariants.h2}>{ operation.summary }</Text>
-                                <Text component={TextVariants.p}>{verb.toUpperCase()} {path}</Text>
-                                <Text component={TextVariants.p}>{operation.description}</Text>
-                            </TextContent>
-                        </StackItem>
-                        { parameters.length > 0 && <StackItem>
-                            <TextContent>
-                                <Text component={TextVariants.h3}>Parameters</Text>
-                            </TextContent>
-                            <TableComposable>
-                                <Thead>
-                                    <Tr>
-                                        <Td>Name</Td>
-                                        <Td>In</Td>
-                                        <Td>Type</Td>
-                                        <Td>Required</Td>
-                                        <Td>Description</Td>
-                                    </Tr>
-                                </Thead>
-                                <Tbody>
-                                    {parameters.map(((p, index) => (
-                                        <Tr key={index}>
-                                            <Td>{p.name}</Td>
-                                            <Td>{p.in}</Td>
-                                            <Td>{getType(p.schema, document)}</Td>
-                                            <Td>{p.required ? 'Yes' : 'No'}</Td>
-                                            <Td>{p.description}</Td>
-                                        </Tr>
-                                    )))}
-                                </Tbody>
-                            </TableComposable>
-                        </StackItem> }
-                        { responseMap.length > 0 && <StackItem>
-                            <TextContent>
-                                <Text component={TextVariants.h3}>Responses</Text>
-                            </TextContent>
-                            <TableComposable>
-                                <Thead>
-                                    <Tr>
-                                        <Td>Status</Td>
-                                        <Td>Description</Td>
-                                        <Td>Schema</Td>
-                                    </Tr>
-                                </Thead>
-                                <Tbody>
-                                    {responseMap.map(([code, response]) => {
-                                        const dResponse = deRef(response, document);
-                                        return <Tr key={code}>
-                                            <Td>{code}</Td>
-                                            <Td>{dResponse.description}</Td>
-                                            <Td>{getResponseSchema(dResponse, document)}</Td>
-                                        </Tr>;
-                                    })}
-                                </Tbody>
-                            </TableComposable>
-                            {responseExample && <ExampleResponse response={responseExample} />}
-                        </StackItem> }
-                    </Stack>
-                </FlexItem>
-                <FlexItem flex={{default: 'flex_1'}}>
-                    <CodeSamples parameters={parameters} verb={verb} path={path}/>
-                </FlexItem>
-            </Flex>;
+    return <Grid className="pf-u-mt-sm" hasGutter>
+            <GridItem className="pf-m-12-col pf-m-7-col-on-lg pf-m-8-col-on-xl">
+              <Stack hasGutter>
+                <StackItem>
+                  <TextContent>
+                    <Text component={TextVariants.h2}>{ operation.summary }</Text>
+                    <Text component={TextVariants.p}>{verb.toUpperCase()} {path}</Text>
+                    <Text component={TextVariants.p}>{operation.description}</Text>
+                  </TextContent>
+                </StackItem>
+                { parameters.length > 0 && <StackItem>
+                  <TextContent>
+                    <Text component={TextVariants.h3}>Parameters</Text>
+                  </TextContent>
+                  <TableComposable variant="compact">
+                    <Thead>
+                      <Tr>
+                        <Td>Name</Td>
+                        <Td>In</Td>
+                        <Td>Type</Td>
+                        <Td>Required</Td>
+                        <Td>Description</Td>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {parameters.map(((p, index) => (
+                        <Tr key={index}>
+                          <Td>{p.name}</Td>
+                          <Td>{p.in}</Td>
+                          <Td>{getType(p.schema, document)}</Td>
+                          <Td>{p.required ? 'Yes' : 'No'}</Td>
+                          <Td>{p.description}</Td>
+                        </Tr>
+                      )))}
+                    </Tbody>
+                  </TableComposable>
+                  </StackItem> }
+                  { responseMap.length > 0 && <StackItem>
+                    <TextContent>
+                      <Text component={TextVariants.h3}>Responses</Text>
+                    </TextContent>
+                    <TableComposable variant="compact">
+                      <Thead>
+                        <Tr>
+                          <Td>Status</Td>
+                          <Td>Description</Td>
+                          <Td>Schema</Td>
+                        </Tr>
+                      </Thead>
+                      <Tbody>
+                      {responseMap.map(([code, response]) => {
+                        const dResponse = deRef(response, document);
+                        return <Tr key={code}>
+                          <Td>{code}</Td>
+                          <Td>{dResponse.description}</Td>
+                          <Td>{getResponseSchema(dResponse, document)}</Td>
+                        </Tr>;
+                      })}
+                      </Tbody>
+                    </TableComposable>
+                    {responseExample && <ExampleResponse response={responseExample} />}
+                  </StackItem> }
+                </Stack>
+              </GridItem>
+              <GridItem className="pf-m-12-col pf-m-5-col-on-lg pf-m-4-col-on-xl pf-u-my-2xl-on-lg pf-u-ml-md-on-lg">
+                <CodeSamples parameters={parameters} verb={verb} path={path}/>
+              </GridItem>
+            </Grid>;
 }
 
 const getResponseSchema = (response: OpenAPIV3.ResponseObject, document: OpenAPIV3.Document) => {

--- a/src/components/SideBar/SearchBar.tsx
+++ b/src/components/SideBar/SearchBar.tsx
@@ -10,12 +10,12 @@ export const SearchInputBasic: React.FunctionComponent = () => {
 
   return (
     <div>
-        <SearchInput className="pf-c-search-input"
-            placeholder="Find by product or service name"
-            value={value}
-            onChange={(_event, value) => onChange(value)}
-            onClear={() => onChange('')}
-        />
+      <SearchInput
+          placeholder="Find by product or service name"
+          value={value}
+          onChange={(_event, value) => onChange(value)}
+          onClear={() => onChange('')}
+      />
     </div>
   );
 };

--- a/src/components/SideBar/Sidebar.tsx
+++ b/src/components/SideBar/Sidebar.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import { Form, PageSection, PageSectionVariants, Sidebar } from '@patternfly/react-core';
+import { Form } from '@patternfly/react-core';
 import { SearchInputBasic } from './SearchBar';
 import { CheckboxControlled } from './CheckBox';
 
 export const SidebarBasic: React.FunctionComponent = () => (
-  <PageSection variant={PageSectionVariants.light} stickyOnBreakpoint={{ default: 'top' }}>
-    <Sidebar hasGutter>
-      <Form>
-        <SearchInputBasic/>
-        <CheckboxControlled/>
-      </Form>
-    </Sidebar>
-  </PageSection>
+  <Form>
+    <SearchInputBasic/>
+    <CheckboxControlled/>
+  </Form>
 );

--- a/src/pages/APIPage.tsx
+++ b/src/pages/APIPage.tsx
@@ -1,6 +1,6 @@
 import {FunctionComponent, useEffect, useMemo, useState} from 'react';
 import {
-    Breadcrumb, BreadcrumbItem, Bullseye,
+    Breadcrumb, BreadcrumbItem, Bullseye, Divider,
     Page,
     PageSection,
     PageSectionVariants, Spinner,
@@ -53,7 +53,8 @@ export const APIPage: FunctionComponent = () => {
     }
 
     return <Page className="apid-c-page-apipage">
-        <PageSection variant={PageSectionVariants.light}>
+        <PageSection variant={PageSectionVariants.light} className="pf-u-pb-sm">
+
             <Breadcrumb>
                 <BreadcrumbItem to='#' onClick={(event) => {
                     event.preventDefault();
@@ -61,6 +62,7 @@ export const APIPage: FunctionComponent = () => {
                 }} >API Documentation and Guides</BreadcrumbItem>
                 <BreadcrumbItem isActive>{api}</BreadcrumbItem>
             </Breadcrumb>
+            <Divider className="pf-u-mt-md" />
         </PageSection>
         <PageSection variant={PageSectionVariants.light}>
             { (apiState.isLoading || !apiState.api) ?

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -3,12 +3,13 @@ import {
   Button,
   Gallery,
   GalleryItem,
-  Grid,
-  GridItem,
   Page,
   PageGroup,
   PageSection,
   PageSectionVariants,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
   Split,
   SplitItem,
   Text,
@@ -19,20 +20,19 @@ import {apiConfigurations} from "../config/apis";
 import {Card} from "../components/Card/Card";
 import {SidebarBasic} from "../components/SideBar/Sidebar";
 import {useNavigate} from "react-router";
-
-import APIConfigurationIcons from '../config/APIConfigurationIcons';
-
 import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 import ThListIcon from '@patternfly/react-icons/dist/js/icons/th-list-icon';
 
+import APIConfigurationIcons from '../config/APIConfigurationIcons';
+
 export const LandingPage: FunctionComponent = () => {
   const navigate = useNavigate();
-    return <Page className="apid-c-page-landingpage pf-u-background-color-200 pf-m-full-height">
-      <Grid>
-        <GridItem span={2}>
+    return <Page className="apid-c-page-landingpage pf-u-background-color-100">
+      <Sidebar className="apid-c-sidebar">
+        <SidebarPanel className="pf-u-p-lg">
           <SidebarBasic/>
-        </GridItem>
-        <GridItem span={10}>
+        </SidebarPanel>
+        <SidebarContent>
           <PageGroup stickyOnBreakpoint={{ default: 'top' }}>
             <PageSection variant={PageSectionVariants.darker} className="pf-u-px-2xl-on-md pf-u-pb-2xl pf-u-background-color-dark-100">
               <TextContent>
@@ -43,7 +43,7 @@ export const LandingPage: FunctionComponent = () => {
                 </Text>
               </TextContent>
             </PageSection>
-            <PageSection variant={PageSectionVariants.light} className="pf-u-px-2xl-on-md">
+            <PageSection variant={PageSectionVariants.light} className="pf-u-px-lg-on-md">
               <Split>
                 <SplitItem>
                   <div className="pf-c-dropdown isDisabled">
@@ -75,16 +75,16 @@ export const LandingPage: FunctionComponent = () => {
               </Split>
             </PageSection>
           </PageGroup>
-          <PageSection className="pf-u-px-2xl-on-md">
-            <Gallery hasGutter>
+          <PageSection className="pf-u-px-lg-on-md">
+            <Gallery minWidths={{default: '300px'}} hasGutter>
               { apiConfigurations.map(apiConfig => (
                 <GalleryItem key={apiConfig.displayName}>
-                <Card displayName={apiConfig.displayName} icon={apiConfig.icon ?? APIConfigurationIcons.GenericIcon} description={apiConfig.description} onClick={() => navigate(`/api/${apiConfig.id}`)} />
+                 <Card displayName={apiConfig.displayName} icon={apiConfig.icon ?? APIConfigurationIcons.GenericIcon} description={apiConfig.description} onClick={() => navigate(`/api/${apiConfig.id}`)} />
                 </GalleryItem>
               ))}
-            </Gallery>
+              </Gallery>
           </PageSection>
-        </GridItem>
-      </Grid>
+        </SidebarContent>
+      </Sidebar>
     </Page>;
 };


### PR DESCRIPTION
- Make Operation section responsive /tweak styling
- Make tables compact
- Add breadcrumb divider
- Add landing page card min-width
- Update sidebar styling

![Screenshot 2023-02-15 at 9 58 09 PM](https://user-images.githubusercontent.com/1287144/219256835-d1bce638-fbf7-43f1-8373-a1df4bf04935.png)

![Screenshot 2023-02-15 at 12 43 44 PM](https://user-images.githubusercontent.com/1287144/219110301-1dffda95-1a4f-4d1f-bf47-b6979eb64d4c.png)

![Screenshot 2023-02-15 at 12 44 34 PM](https://user-images.githubusercontent.com/1287144/219110446-fec21d6e-629a-4f32-bace-05726fa03470.png)

