### PR TITLE
Update SchemaView Styling

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -108,3 +108,24 @@
     padding-left: 4em;
   }
 }
+
+.apid-schemas {
+  .pf-c-accordion__toggle {
+    flex-direction: row-reverse;
+
+    .pf-c-accordion__toggle-text {
+      flex-grow: 1;
+      text-align: left;
+      margin-left: 0.5em;
+    }
+  }
+
+  .pf-c-accordion__expanded-content-body {
+    padding-left: 1.5em;
+  }
+
+  .pf-c-tree-view {
+    --pf-c-tree-view--m-compact__node-container--PaddingTop: 0.5rem;
+    --pf-c-tree-view--m-compact__node-container--PaddingBottom: 0.5rem;
+  }
+}

--- a/src/App.scss
+++ b/src/App.scss
@@ -110,6 +110,13 @@
 }
 
 .apid-schemas {
+  .schema-name {
+    margin-right: 20px;
+  }
+  .schema-type {
+    color: var(--pf-global--Color--dark-200);
+  }
+
   .pf-c-accordion__toggle {
     flex-direction: row-reverse;
 

--- a/src/components/APIDoc/SchemaDataView.tsx
+++ b/src/components/APIDoc/SchemaDataView.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { TreeView, TreeViewDataItem, Text, TextContent, TextVariants, Flex, FlexItem } from '@patternfly/react-core';
+import React, { useState} from 'react';
+import { TreeView, TreeViewDataItem, Text, TextContent, TextVariants, Flex, FlexItem, AccordionItem, AccordionToggle, AccordionContent } from '@patternfly/react-core';
 import { OpenAPIV3 } from 'openapi-types';
 
 import { deRef, DeRefResponse } from '../../utils/Openapi';
-
 
 export interface SchemaDataViewProps {
   schemaName: string;
@@ -15,8 +14,21 @@ export interface SchemaDataViewProps {
 export const SchemaDataView: React.FunctionComponent<SchemaDataViewProps> = ({ schemaName, schema, document, propDeRef }) => {
   const schemaData = getTreeViewData(schemaName, schema, document, propDeRef)
 
-  const data = [{title: schemaName, children: schemaData, id: schemaName}] as TreeViewDataItem[]
-  return <TreeView data={data} variant="compactNoBackground" />;
+  const id = `schema-${schemaName}`;
+  const [isExpanded, setExpanded] = useState(false);
+
+  return <AccordionItem>
+      <AccordionToggle
+          id={id}
+          isExpanded={isExpanded}
+          onClick={() => setExpanded(prev => !prev)}
+      >
+          <span className="schema-name">{schemaName}</span>
+      </AccordionToggle>
+      { isExpanded && <AccordionContent>
+        <TreeView data={schemaData} variant="compactNoBackground" />
+      </AccordionContent>}
+  </AccordionItem>;
 };
 
 

--- a/src/components/APIDoc/SchemaDataView.tsx
+++ b/src/components/APIDoc/SchemaDataView.tsx
@@ -24,6 +24,7 @@ export const SchemaDataView: React.FunctionComponent<SchemaDataViewProps> = ({ s
           onClick={() => setExpanded(prev => !prev)}
       >
           <span className="schema-name">{schemaName}</span>
+          <span className="schema-type">{schema.type ? schema.type : 'object'} </span>
       </AccordionToggle>
       { isExpanded && <AccordionContent>
         <TreeView data={schemaData} variant="compactNoBackground" />

--- a/src/components/APIDoc/SchemaViewer.tsx
+++ b/src/components/APIDoc/SchemaViewer.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { OpenAPIV3 } from 'openapi-types';
 import { SchemaDataView } from './SchemaDataView';
 import { deRef } from '../../utils/Openapi';
-import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { Accordion, Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 interface SchemaViewerProps {
     document: OpenAPIV3.Document
@@ -18,11 +18,12 @@ export const SchemaViewer: React.FunctionComponent<SchemaViewerProps> = ({ docum
                     Schemas
                 </Text>
             </TextContent>
-            {
-                schemas && Object.entries(schemas).map(([schemaName, schemaObject]) => {
+            <Accordion className="apid-schemas" isBordered>
+            {   schemas && Object.entries(schemas).map(([schemaName, schemaObject]) => {
                     return <SchemaDataView schemaName={schemaName} schema={deRef(schemaObject, document)} document={document} propDeRef={true} />
                 })
             }
+            </Accordion>
         </>
     )
 }


### PR DESCRIPTION
Some styling updates for the SchemaView component to blend with the page more easily.

Before:
![image](https://user-images.githubusercontent.com/17099954/220186189-6076bba7-eaa8-4ed2-8fb1-25bc49b4c5d3.png)

After:
![image](https://user-images.githubusercontent.com/17099954/220187895-d6451213-c23f-40cc-aa58-6e45930c7b94.png)
