### PR TITLE
Split discovery checks in 2 tests & create PR with new API changes

### DIFF
--- a/.github/workflows/sync-discovery.yml
+++ b/.github/workflows/sync-discovery.yml
@@ -7,6 +7,8 @@ name: Sync discovery
 on:
   schedule:
     - cron: "0 0 * * *"
+  push:
+    branches: [ "main" ]
 
 
 jobs:

--- a/.github/workflows/sync-discovery.yml
+++ b/.github/workflows/sync-discovery.yml
@@ -1,0 +1,33 @@
+# This workflow will review the current status of the APIs. It will verify if the API is:
+#  - Reachable, i.e. we can download it.
+#  - Following OpenapiV3+
+
+name: Sync discovery
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run discovery
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        title: Syncing API
+        commit-message: Syncing API
+        delete-branch: true

--- a/.github/workflows/validate-discovery-apps.yml
+++ b/.github/workflows/validate-discovery-apps.yml
@@ -2,15 +2,11 @@
 #  - Reachable, i.e. we can download it.
 #  - Following OpenapiV3+
 
-name: Discovery
+name: Validate discovery apps
 
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull_request:
-    branches: [ "main" ]
-    paths:
-      - 'discovery/**'
 
 
 jobs:
@@ -28,4 +24,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm exec jest --src discovery
+    - run: npm exec jest --src discovery/Validate.test.ts

--- a/.github/workflows/validate-discovery-file.yml
+++ b/.github/workflows/validate-discovery-file.yml
@@ -1,0 +1,29 @@
+# This workflow will review the current status of the APIs. It will verify if the API is:
+#  - Reachable, i.e. we can download it.
+#  - Following OpenapiV3+
+
+name: Validate discovery file
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'discovery/**'
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm exec jest --src discovery/Discovery.test.ts

--- a/discovery/Discovery.test.ts
+++ b/discovery/Discovery.test.ts
@@ -1,6 +1,5 @@
 import {App, Discovery, getPath, Tag} from "./Discovery";
-import SwaggerParser from '@apidevtools/swagger-parser';
-import {readFileSync} from 'fs';
+import {readFileSync, existsSync} from 'fs';
 import path from 'path';
 import {parse} from 'yaml';
 import Ajv from 'ajv';
@@ -29,16 +28,6 @@ const publicApiFilter = (app: App): boolean => !skipFilter(app) && !app.useLocal
 const privateApiFilter = (app: App): boolean => !skipFilter(app) && !!app.useLocalFile;
 const idMapper = (withId: WithId): string => withId.id;
 
-const validApiTest = async (_ignore: string, app: App, groupId: string) => {
-    const api = await SwaggerParser.validate(getPath(app, groupId));
-    expect(api).toBeTruthy();
-
-    expect(api).toHaveProperty('openapi');
-
-    const version = (api as any).openapi as string;
-    expect(version).toMatch(/^3(.\d(.\d)?)?/);
-}
-
 const expectNonRepeatedIds = (arrayOfItemsWithId: Array<WithId>) => {
     const idSet = new Set(arrayOfItemsWithId.map(idMapper));
     const repeatedIds = [];
@@ -53,7 +42,7 @@ const expectNonRepeatedIds = (arrayOfItemsWithId: Array<WithId>) => {
     expect(repeatedIds).toHaveLength(0);
 }
 
-describe('Discovered OpenAPI are valid OpenAPI3.0+', () => {
+describe('Discovery', () => {
 
     test('Discovery file is valid', () => {
         const validate = new Ajv().compile(DiscoverySchema);
@@ -70,10 +59,6 @@ describe('Discovered OpenAPI are valid OpenAPI3.0+', () => {
 
     describe.each(Object.values(discovery.apis).map(g => [`${g.name}(${g.id})`, g.apps, g.id]))('%s', (_ignore, apps, group) => {
         const prepareApp = (app: App) => [`${app.name}(${app.id})`, app, group] as const;
-
-        const skipped = apps.filter(skipFilter);
-
-        const appsWithPublicUrls = apps.filter(publicApiFilter);
         const appsWithNonPublicUrls = apps.filter(privateApiFilter);
 
         test('No repeated app.id within groups', () => {
@@ -90,34 +75,12 @@ describe('Discovered OpenAPI are valid OpenAPI3.0+', () => {
             }
         })
 
-        test('Testing all APIs one way or another', () => {
-            const allPieces = [
-                ...skipped.map(idMapper),
-                ...appsWithPublicUrls.map(idMapper),
-                ...appsWithNonPublicUrls.map(idMapper)
-            ];
-
-            expect(allPieces).toHaveLength(apps.length);
-            expect(allPieces).toEqual(expect.arrayContaining(apps.map(idMapper)));
-        });
-
-        if (appsWithPublicUrls.length > 0) {
-            describe('public url', () => {
-                test.each(appsWithPublicUrls.map(prepareApp))('%s', validApiTest);
-            });
-        }
-
         if (appsWithNonPublicUrls.length > 0) {
             describe('local file', () => {
-                test.each(appsWithNonPublicUrls.map(prepareApp))('%s', validApiTest);
-            });
-        }
-        if (skipped.length > 0) {
-            describe('Skipped', () => {
-                test.skip.each(skipped.map(a => `${a.name}(${a.id}) - ${skipReason(a)}`))('%s', () => {
-                    throw new Error('Should skip this test');
+                test.each(appsWithNonPublicUrls.map(prepareApp))('%s', (_ignore: string, app: App, groupId: string) => {
+                    expect(existsSync(getPath(app, groupId))).toBeTruthy();
                 });
-            })
+            });
         }
     })
 });

--- a/discovery/Validate.test.ts
+++ b/discovery/Validate.test.ts
@@ -1,0 +1,79 @@
+import {App, Discovery, getPath} from "./Discovery";
+import SwaggerParser from '@apidevtools/swagger-parser';
+import {readFileSync} from 'fs';
+import path from 'path';
+import {parse} from 'yaml';
+
+const discovery: Discovery = parse(readFileSync(path.resolve(__dirname, 'Discovery.yml')).toString());
+
+type WithId = {
+    id: string;
+}
+
+const skipReason = (app: App) => {
+    if (app.skip) {
+        return app.skipReason;
+    }
+
+    if (app.apiType !== 'openapi-v3') {
+        return `Only OpenApiV3 is supported right now. App has ${app.apiType}`;
+    }
+
+    throw new Error('No valid reason to skip this test');
+};
+
+const skipFilter = (app: App): boolean => app.skip || app.apiType  !== 'openapi-v3';
+const publicApiFilter = (app: App): boolean => !skipFilter(app) && !app.useLocalFile;
+const privateApiFilter = (app: App): boolean => !skipFilter(app) && !!app.useLocalFile;
+const idMapper = (withId: WithId): string => withId.id;
+
+const validApiTest = async (_ignore: string, app: App, groupId: string) => {
+    const api = await SwaggerParser.validate(getPath(app, groupId));
+    expect(api).toBeTruthy();
+
+    expect(api).toHaveProperty('openapi');
+
+    const version = (api as any).openapi as string;
+    expect(version).toMatch(/^3(.\d(.\d)?)?/);
+}
+
+describe('Discovered OpenAPI are valid OpenAPI3.0+', () => {
+    describe.each(Object.values(discovery.apis).map(g => [`${g.name}(${g.id})`, g.apps, g.id]))('%s', (_ignore, apps, group) => {
+        const prepareApp = (app: App) => [`${app.name}(${app.id})`, app, group] as const;
+
+        const skipped = apps.filter(skipFilter);
+
+        const appsWithPublicUrls = apps.filter(publicApiFilter);
+        const appsWithNonPublicUrls = apps.filter(privateApiFilter);
+
+        test('Testing all APIs one way or another', () => {
+            const allPieces = [
+                ...skipped.map(idMapper),
+                ...appsWithPublicUrls.map(idMapper),
+                ...appsWithNonPublicUrls.map(idMapper)
+            ];
+
+            expect(allPieces).toHaveLength(apps.length);
+            expect(allPieces).toEqual(expect.arrayContaining(apps.map(idMapper)));
+        });
+
+        if (appsWithPublicUrls.length > 0) {
+            describe('public url', () => {
+                test.each(appsWithPublicUrls.map(prepareApp))('%s', validApiTest);
+            });
+        }
+
+        if (appsWithNonPublicUrls.length > 0) {
+            describe('local file', () => {
+                test.each(appsWithNonPublicUrls.map(prepareApp))('%s', validApiTest);
+            });
+        }
+        if (skipped.length > 0) {
+            describe('Skipped', () => {
+                test.skip.each(skipped.map(a => `${a.name}(${a.id}) - ${skipReason(a)}`))('%s', () => {
+                    throw new Error('Should skip this test');
+                });
+            })
+        }
+    })
+});

--- a/transform/src/main.ts
+++ b/transform/src/main.ts
@@ -56,14 +56,16 @@ export const execute = async (options: Options) => {
             .map(async (app) => {
                 return await limit(async (): Promise<BuildApi> => {
                     let content = {};
-                    let apiIsValid;
+                    let apiIsValid = false;
                     try {
                         const apiContent = await getApiContent(discoveryPath, app, group.id);
                         content = JSON.parse(apiContent);
                         await SwaggerParser.validate(JSON.parse(apiContent) as OpenAPI.Document);
-                        apiIsValid = true;
+                        if ('openapi' in content && typeof content.openapi === 'string' && content.openapi.match(/^3(.\d(.\d)?)?/)) {
+                            apiIsValid = true;
+                        }
                     } catch {
-                        apiIsValid = false;
+                        // Ignore exceptions, API is not valid.
                     }
 
                     return ({


### PR DESCRIPTION
This splits the discovery checks in 2 tests and 1 additional action to sync changes.

Right now is set to run at 00 UTC and create a PR if there is any change - We can follow up on this behavior and move to a regular commit instead if it works well enough for us.