### PR TITLE
Disable recursive dereference to fix bug in recursion and making the schema more readable

### DIFF
--- a/src/components/APIDoc/SchemaViewer.tsx
+++ b/src/components/APIDoc/SchemaViewer.tsx
@@ -20,7 +20,7 @@ export const SchemaViewer: React.FunctionComponent<SchemaViewerProps> = ({ docum
             </TextContent>
             <Accordion className="apid-schemas" isBordered>
             {   schemas && Object.entries(schemas).map(([schemaName, schemaObject]) => {
-                    return <SchemaDataView schemaName={schemaName} schema={deRef(schemaObject, document)} document={document} propDeRef={true} />
+                    return <SchemaDataView schemaName={schemaName} schema={deRef(schemaObject, document)} document={document}/>
                 })
             }
             </Accordion>


### PR DESCRIPTION
Screenshot:
![image](https://user-images.githubusercontent.com/17099954/220442382-3fe66dc9-3cbb-4a8f-8d45-0d11dc54cfcd.png)

We will still need the treeview component to handle some situations where they don't provide a schema for us but still have a nested object.

![image](https://user-images.githubusercontent.com/17099954/220442638-91b7f4e6-ef56-45ee-8fb2-37fb45c6be68.png)
