### PR TITLE
Adding RequestBodyView component [RHCLOUD-24409]

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -120,3 +120,7 @@
     --pf-c-tree-view--m-compact__node-container--PaddingBottom: var(--pf-global--spacer--sm);
   }
 }
+
+.apid-reqbody-header {
+  padding-top: var(--pf-global--spacer--md);
+}

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -13,6 +13,7 @@ import {
 import {TableComposable, Tbody, Td, Thead, Tr} from "@patternfly/react-table";
 import {ExampleResponse} from "./ExampleResponse";
 import {CodeSamples} from "./CodeSamples";
+import { RequestBodyView } from './RequestBodyView';
 
 export interface OperationProps {
   verb: string;
@@ -91,6 +92,7 @@ const OperationContent: React.FunctionComponent<OperationProps> = ({verb, path, 
             </Tbody>
           </TableComposable>
           </> }
+          { operation.requestBody && <RequestBodyView requestBody={operation.requestBody} document={document} /> }
           { responseMap.length > 0 && <>
             <TextContent className="pf-u-py-lg">
               <Text component={TextVariants.h3} >Responses</Text>

--- a/src/components/APIDoc/RequestBodyView.tsx
+++ b/src/components/APIDoc/RequestBodyView.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import {OpenAPIV3} from "openapi-types";
+import { deRef, DeRefResponse } from '../../utils/Openapi';
+import { Flex, FlexItem, Text, TextContent, TextVariants } from "@patternfly/react-core";
+import { SchemaDataView } from './SchemaDataView';
+
+
+interface BodySchemaInfo {
+    schemaType: string;
+    schema?: DeRefResponse<OpenAPIV3.ArraySchemaObject | OpenAPIV3.NonArraySchemaObject>;
+    refSchema?: string;
+}
+
+export interface RequestBodyViewProps {
+    requestBody: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject;
+    document: OpenAPIV3.Document;
+}
+export const RequestBodyView: React.FunctionComponent<RequestBodyViewProps> = ({ requestBody, document }) => {
+    let requestBodySchemas = [] as BodySchemaInfo[]
+    let requestBodyRef = undefined
+
+    if (requestBody && 'content' in requestBody) {
+        requestBodySchemas = Object.entries(requestBody.content).map(([mediatype, mediaObject]) => {
+
+        if (mediaObject.schema !== undefined) {
+            const schema = mediaObject.schema as OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject
+            if ('$ref' in schema) {
+                return {schemaType: mediatype, refSchema: schema.$ref.split('/').at(-1) as string}
+            }
+            return {schemaType: mediatype, schema: deRef(schema, document)}
+        }
+        return {schemaType: mediatype, schema: {} as DeRefResponse<OpenAPIV3.NonArraySchemaObject> }
+        })
+    } else if (requestBody) {
+        requestBodyRef = requestBody.$ref.split('/').at(-1) as string
+    }
+
+    return (
+        <>
+            <TextContent>
+                <Text component={TextVariants.h3} className="pf-u-pb-lg apid-reqbody-header">Request Body Schema</Text>
+            </TextContent>
+            {
+                requestBodySchemas.map((bodySchema) => {
+                    if (bodySchema.schema) {
+                        return <SchemaDataView schemaName={bodySchema.schemaType} schema={bodySchema.schema} document={document} />
+                    }
+                    return bodySchema.refSchema && <RefSchemaView schemaType={bodySchema.schemaType} refSchema={bodySchema.refSchema} />
+                })
+            }
+            {requestBodyRef && <RefSchemaView schemaType="schema" refSchema={requestBodyRef}/>}
+        </>
+    )
+}
+
+interface RefSchemaViewProps {
+    schemaType: string;
+    refSchema: string;
+}
+export const RefSchemaView: React.FunctionComponent<RefSchemaViewProps> = ({ schemaType, refSchema }) => {
+    return(
+        <TextContent>
+            <Flex>
+                <FlexItem>
+                    <Text component={TextVariants.p}>{schemaType}</Text>
+                </FlexItem>
+                <FlexItem>
+                    <Text component={TextVariants.h6}>{refSchema}</Text>
+                </FlexItem>
+            </Flex>
+        </TextContent>
+    )
+}


### PR DESCRIPTION
Adding a component to the request body schema. Very common in POST, PUT and PATCH endpoints.

Referenced:
![image](https://user-images.githubusercontent.com/17099954/224406231-39fb213c-6a4f-4530-b6be-a22c767c33b7.png)

Inline schema (Re-uses the `SchemaDataView` component):
![image](https://user-images.githubusercontent.com/17099954/224406454-756d5ef9-b218-4124-b59c-1073ce0cc81d.png)
