### PR TITLE
Showing schema of undefined types and fixing typo in SchemaPropertyView

### DIFF
--- a/src/components/APIDoc/SchemaDataView.tsx
+++ b/src/components/APIDoc/SchemaDataView.tsx
@@ -139,7 +139,7 @@ const getTreeViewData = (schemaName: string, schema: DeRefResponse<OpenAPIV3.Arr
     } else if ('$ref' in value ) {
       propertyType = value.$ref.split('/').at(-1) as string
     }  else {
-      propertyType = 'type' in value ? value.type as string : 'any/undefined type'
+      propertyType = 'type' in value ? value.type as string : 'any type'
 
       if ('items' in value) {
         const itemConditionalSchema = findConditionKey(value.items)

--- a/src/components/APIDoc/SchemaDataView.tsx
+++ b/src/components/APIDoc/SchemaDataView.tsx
@@ -136,8 +136,10 @@ const getTreeViewData = (schemaName: string, schema: DeRefResponse<OpenAPIV3.Arr
     if (conditionalSchema) {
       const {schemaKey, schemaVal} = conditionalSchema
       children = [{name: <ConditionSchema condition={schemaKey} schemas={schemaVal} document={document}/>}] as TreeViewDataItem[]
-    } else if ('type' in value) {
-      propertyType = value.type as string
+    } else if ('$ref' in value ) {
+      propertyType = value.$ref.split('/').at(-1) as string
+    }  else {
+      propertyType = 'type' in value ? value.type as string : 'any/undefined type'
 
       if ('items' in value) {
         const itemConditionalSchema = findConditionKey(value.items)
@@ -158,10 +160,6 @@ const getTreeViewData = (schemaName: string, schema: DeRefResponse<OpenAPIV3.Arr
         const items = deRef(value, document)
         children = getTreeViewData(schemaName, items, document)
       }
-    } else if ('$ref' in value ) {
-      propertyType = value.$ref.split('/').at(-1) as string
-    } else {
-      propertyType = "schema undefined"
     }
 
     return {

--- a/src/components/APIDoc/SchemaPropertyView.tsx
+++ b/src/components/APIDoc/SchemaPropertyView.tsx
@@ -64,7 +64,7 @@ export const ExtraPropertyView:React.FunctionComponent<ExtraPropertyViewProps> =
   } else if (propSchema.maxLength) {
     maxMinChar = `max ${propSchema.maxLength} chars`
   } else if (propSchema.minLength) {
-    maxMinChar = `max ${propSchema.minLength} chars`
+    maxMinChar = `min ${propSchema.minLength} chars`
   }
 
   let maxMinItems: string | undefined;


### PR DESCRIPTION
Undefined `type` in schema can still be valid schema.
![image](https://user-images.githubusercontent.com/17099954/227605619-4c4736fa-82a5-42f1-953e-935cc98bafa7.png)

Also, fixed a typo with `minLength`.

