### PR TITLE
Fixing codesamples always selected bug [RHCLOUD-24399]

### DIFF
--- a/src/components/APIDoc/CodeBlockDropdown.tsx
+++ b/src/components/APIDoc/CodeBlockDropdown.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 import { Language } from '@patternfly/react-code-editor';
 
-export interface DropdownItem {
+export interface DropdownItemInfo {
   value: string;
   text: string;
   language: Language;
 }
 
 export interface CodeBlockDropdownProps {
-  dropdownItems: DropdownItem[];
-  setLanguage: React.Dispatch<React.SetStateAction<DropdownItem>>;
+  dropdownItems: DropdownItemInfo[];
+  setLanguage: React.Dispatch<React.SetStateAction<DropdownItemInfo>>;
 }
 
 export const CodeBlockDropdown: React.FunctionComponent<CodeBlockDropdownProps> = ({dropdownItems, setLanguage}) => {
@@ -31,7 +31,7 @@ export const CodeBlockDropdown: React.FunctionComponent<CodeBlockDropdownProps> 
     onFocus();
   };
 
-  const onDropdownSelect = (event: any, item: DropdownItem) => {
+  const onDropdownSelect = (event: any, item: DropdownItemInfo) => {
     setSelected(item.value);
     setLanguage(item);
   }

--- a/src/components/APIDoc/CodeBlockDropdown.tsx
+++ b/src/components/APIDoc/CodeBlockDropdown.tsx
@@ -2,32 +2,20 @@ import React from 'react';
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 import { Language } from '@patternfly/react-code-editor';
 
-import { templates } from '../../resources/codesampletemplates/Templates';
-
-interface Item {
+export interface DropdownItem {
   value: string;
   text: string;
   language: Language;
 }
 
-const items: Item[] = [
-  {value: "go", text: "go", language: Language.go},
-  {value: "java", text: "java", language: Language.java},
-  {value: "node", text: "node", language: Language.javascript},
-  {value: "python", text: "python", language: Language.python},
-  {value: "cURL", text: "cURL", language: Language.shell},
-]
-
 export interface CodeBlockDropdownProps {
-    setTemplate: React.Dispatch<React.SetStateAction<string>>;
-    setLanguage: React.Dispatch<React.SetStateAction<Language>>;
+  dropdownItems: DropdownItem[];
+  setLanguage: React.Dispatch<React.SetStateAction<DropdownItem>>;
 }
 
-export const CodeBlockDropdown: React.FunctionComponent<CodeBlockDropdownProps> = ({setTemplate, setLanguage}) => {
+export const CodeBlockDropdown: React.FunctionComponent<CodeBlockDropdownProps> = ({dropdownItems, setLanguage}) => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState("go");
-
-  setTemplate(templates[selected])
+  const [selected, setSelected] = React.useState(dropdownItems[0].value);
 
   const onToggle = (isOpen: boolean) => {
     setIsOpen(isOpen);
@@ -43,10 +31,9 @@ export const CodeBlockDropdown: React.FunctionComponent<CodeBlockDropdownProps> 
     onFocus();
   };
 
-  const onDropdownSelect = (event: any, item: Item) => {
+  const onDropdownSelect = (event: any, item: DropdownItem) => {
     setSelected(item.value);
-    setLanguage(item.language)
-    setTemplate(templates[item.value]);
+    setLanguage(item);
   }
 
   return (
@@ -58,7 +45,7 @@ export const CodeBlockDropdown: React.FunctionComponent<CodeBlockDropdownProps> 
         </DropdownToggle>
       }
       isOpen={isOpen}
-      dropdownItems={items.map((item, index)=> <DropdownItem key={item.value} value={item.value} onClick={(e)=>onDropdownSelect(e, item)}>{item.text}</DropdownItem>)}
+      dropdownItems={dropdownItems.map((item, index)=> <DropdownItem key={item.value} value={item.value} onClick={(e)=>onDropdownSelect(e, item)}>{item.text}</DropdownItem>)}
       isPlain
     />
   );

--- a/src/components/APIDoc/CodeSamples.tsx
+++ b/src/components/APIDoc/CodeSamples.tsx
@@ -5,7 +5,8 @@ import { Card, CardBody, CardHeader, ClipboardCopyButton, FlexItem } from '@patt
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import Dot from 'dot';
 
-import { CodeBlockDropdown } from './CodeBlockDropdown';
+import { DropdownItem, CodeBlockDropdown } from './CodeBlockDropdown';
+import { templates } from '../../resources/codesampletemplates/Templates';
 
 
 interface CodeSampleProps {
@@ -18,6 +19,7 @@ type paramInfo = {
     name : string;
     exampleValues : object;
 }
+
 type templateData = {
     allHeaders: paramInfo[];
     bodyParameter: paramInfo[];
@@ -28,13 +30,24 @@ type templateData = {
     requiredQueryString: string;
 }
 
-export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({parameters, verb, path}) => {
-    const [template, setTemplate] = useState<string>("")
-    const [language, setLanguage] = useState<Language>(Language.go)
-    const [copied, setCopied] = useState<boolean>(false);
+interface samplesMap {
+  [key: string]: string;
+}
 
-    Dot.templateSettings.varname = 'data'
-    Dot.templateSettings.strip = false
+Dot.templateSettings.varname = 'data'
+Dot.templateSettings.strip = false
+
+export const DropdownItems: DropdownItem[] = [
+  {value: "go", text: "go", language: Language.go},
+  {value: "java", text: "java", language: Language.java},
+  {value: "node", text: "node", language: Language.javascript},
+  {value: "python", text: "python", language: Language.python},
+  {value: "cURL", text: "cURL", language: Language.shell},
+]
+
+export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({parameters, verb, path}) => {
+    const [language, setLanguage] = useState<DropdownItem>(DropdownItems[0])
+    const [copied, setCopied] = useState<boolean>(false);
 
     const data: templateData = {
         allHeaders: [{name: "Accept", exampleValues: {json: "application/json"}}],
@@ -48,8 +61,13 @@ export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({parameter
 
     verb !== "get" && data.allHeaders.push({name: "Content-Type", exampleValues: {json: "application/json"}})
 
-    const tempFn = Dot.template(template)
-    const code = tempFn(data)
+    const sampleCollection: samplesMap = {};
+    Object.entries(templates).forEach(([lang, temp]) => {
+      const testFn = Dot.template(temp)
+      sampleCollection[lang] = testFn(data).toString()
+    });
+
+    const code = sampleCollection[language.text]
 
     const clipboardCopyFunc = (event: any, text: string) => {
         navigator.clipboard.writeText(text);
@@ -66,12 +84,12 @@ export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({parameter
           <FlexItem className="pf-u-flex-grow-1 pf-u-pl-lg">
           </FlexItem>
           <FlexItem align={{ default: 'alignRight' }}>
-            <CodeBlockDropdown setTemplate={setTemplate} setLanguage={setLanguage}/>
+            <CodeBlockDropdown dropdownItems={DropdownItems} setLanguage={setLanguage}/>
             <ClipboardCopyButton
               id="basic-copy-button"
               textId="code-content"
               aria-label="Copy to clipboard"
-              onClick={e => onCopyClick(e, code.toString())}
+              onClick={e => onCopyClick(e, code)}
               exitDelay={copied ? 1500 : 600}
               variant="plain"
               onTooltipHidden={() => setCopied(false)}
@@ -85,8 +103,8 @@ export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({parameter
             isDarkTheme={true}
             isLineNumbersVisible={false}
             isReadOnly={true}
-            code={code.toString()}
-            language={language}
+            code={code}
+            language={language.language}
             height="400px"
           />
       </CardBody>

--- a/src/components/APIDoc/CodeSamples.tsx
+++ b/src/components/APIDoc/CodeSamples.tsx
@@ -5,7 +5,7 @@ import { Card, CardBody, CardHeader, ClipboardCopyButton, FlexItem } from '@patt
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import Dot from 'dot';
 
-import { DropdownItem, CodeBlockDropdown } from './CodeBlockDropdown';
+import { DropdownItemInfo, CodeBlockDropdown } from './CodeBlockDropdown';
 import { templates } from '../../resources/codesampletemplates/Templates';
 
 
@@ -37,7 +37,7 @@ interface samplesMap {
 Dot.templateSettings.varname = 'data'
 Dot.templateSettings.strip = false
 
-export const DropdownItems: DropdownItem[] = [
+export const DropdownItems: DropdownItemInfo[] = [
   {value: "go", text: "go", language: Language.go},
   {value: "java", text: "java", language: Language.java},
   {value: "node", text: "node", language: Language.javascript},
@@ -46,7 +46,7 @@ export const DropdownItems: DropdownItem[] = [
 ]
 
 export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({parameters, verb, path}) => {
-    const [language, setLanguage] = useState<DropdownItem>(DropdownItems[0])
+    const [language, setLanguage] = useState<DropdownItemInfo>(DropdownItems[0])
     const [copied, setCopied] = useState<boolean>(false);
 
     const data: templateData = {

--- a/src/resources/codesampletemplates/Templates.ts
+++ b/src/resources/codesampletemplates/Templates.ts
@@ -3,8 +3,8 @@
 const go = `package main
 
 import (
-        "bytes"
-        "net/http"
+    "bytes"
+    "net/http"
 )
 
 func main() {
@@ -27,14 +27,20 @@ func main() {
 const java = `URL obj = new URL("{{=data.url}}{{=data.requiredQueryString}}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("{{=data.methodUpper}}");
+
 int responseCode = con.getResponseCode();
+
 BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
+    new InputStreamReader(con.getInputStream())
+);
+
 String inputLine;
 StringBuffer response = new StringBuffer();
+
 while ((inputLine = in.readLine()) != null) {
     response.append(inputLine);
 }
+
 in.close();
 System.out.println(response.toString());
 `
@@ -46,16 +52,17 @@ const node = `const fetch = require('node-fetch');
 {{~}}};
 {{?}}
 fetch('{{=data.url}}{{=data.requiredQueryString}}',
-{
-  method: '{{=data.methodUpper}}'{{?data.bodyParameter.present || data.allHeaders.length}},{{?}}
-{{?data.bodyParameter.present}}  body: JSON.stringify(inputBody){{?}}{{? data.bodyParameter.present && data.allHeaders.length}},{{?}}
-{{?data.allHeaders.length}}  headers: headers{{?}}
-})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
+    {
+    method: '{{=data.methodUpper}}'{{?data.bodyParameter.present || data.allHeaders.length}},{{?}}
+    {{?data.bodyParameter.present}}  body: JSON.stringify(inputBody){{?}}{{? data.bodyParameter.present && data.allHeaders.length}},{{?}}
+    {{?data.allHeaders.length}}  headers: headers{{?}}
+    })
+    .then(function(res) {
+        return res.json();
+    }).then(function(body) {
+        console.log(body);
+    }
+);
 `
 
 const curl = `# You can also use wget


### PR DESCRIPTION
Apparently the codesamples were showing up a selected because we were evaluating the code strings on the fly.
I changed it so that we evaluate the templates on first load of the component and that seems to fix the issue.

Before:
![image](https://user-images.githubusercontent.com/17099954/228374045-8a25afe4-d903-46d1-9d63-b8958e6832f2.png)

After:
![image](https://user-images.githubusercontent.com/17099954/228374120-b516f9bb-cca1-4926-8970-fd8032ba73af.png)
