### PR TITLE
Add additional data for the codesamples component [RHCLOUD-24399]

### DIFF
--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -52,7 +52,7 @@ export const Operation: React.FunctionComponent<OperationProps> = props => {
 const OperationContent: React.FunctionComponent<OperationProps> = ({verb, path, operation, document}) => {
   const parameters = (operation.parameters || []).map(p => deRef(p, document));
 
-  const [codeSampleLanguage, setCodeSampleLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[0]);
+  const [codeSampleLanguage, setCodeSampleLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[4]);
   const reqData: RequestFormat = useMemo(() => buildCodeSampleData(verb, path, parameters, operation.requestBody, document), [verb, path, codeSampleLanguage]);
 
   const snippets = useSnippets(codeSampleLanguage, reqData);

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import {OpenAPIV3} from "openapi-types";
 import {deRef} from "../../utils/Openapi";
+import { buildCodeSampleData } from '../../utils/Snippets';
 import {
     Grid,
     GridItem,
@@ -47,22 +48,12 @@ export const Operation: React.FunctionComponent<OperationProps> = props => {
   </AccordionItem>;
 };
 
+
 const OperationContent: React.FunctionComponent<OperationProps> = ({verb, path, operation, document}) => {
   const parameters = (operation.parameters || []).map(p => deRef(p, document));
 
   const [codeSampleLanguage, setCodeSampleLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[0]);
-  const reqData: RequestFormat = useMemo(() => ({
-    method: verb.toUpperCase(),
-    url: "http://example.com"+path,
-    httpVersion: "HTTP/1.1",
-    cookies: [],
-    headers: [{name: "Accept", value: "application/json"}], //TODO use headers as per schema. Default to application/json.
-    queryString: [], //TODO path params?
-    postData: undefined, //TODO body params
-    headersSize: -1,
-    bodySize: -1,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [verb, path, codeSampleLanguage]);
+  const reqData: RequestFormat = useMemo(() => buildCodeSampleData(verb, path, parameters, document), [verb, path, codeSampleLanguage]);
 
   const snippets = useSnippets(codeSampleLanguage, reqData);
 

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -53,7 +53,7 @@ const OperationContent: React.FunctionComponent<OperationProps> = ({verb, path, 
   const parameters = (operation.parameters || []).map(p => deRef(p, document));
 
   const [codeSampleLanguage, setCodeSampleLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[0]);
-  const reqData: RequestFormat = useMemo(() => buildCodeSampleData(verb, path, parameters, document), [verb, path, codeSampleLanguage]);
+  const reqData: RequestFormat = useMemo(() => buildCodeSampleData(verb, path, parameters, operation.requestBody, document), [verb, path, codeSampleLanguage]);
 
   const snippets = useSnippets(codeSampleLanguage, reqData);
 

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import {OpenAPIV3} from "openapi-types";
 import {deRef} from "../../utils/Openapi";
-import { buildCodeSampleData } from '../../utils/Snippets';
+import { buildCodeSampleData, BuildCodeSampleDataParams } from '../../utils/Snippets';
 import {
     Grid,
     GridItem,
@@ -52,9 +52,17 @@ export const Operation: React.FunctionComponent<OperationProps> = props => {
 const OperationContent: React.FunctionComponent<OperationProps> = ({verb, path, operation, document}) => {
   const parameters = (operation.parameters || []).map(p => deRef(p, document));
 
-  const [codeSampleLanguage, setCodeSampleLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[4]);
+  const [codeSampleLanguage, setCodeSampleLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[0]);
+  const codeSampleBuildParams: BuildCodeSampleDataParams = {
+    verb: verb,
+    path: path,
+    params: parameters,
+    requestBody: operation.requestBody,
+    responses:  operation.responses,
+    document: document,
+  }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const reqData: RequestFormat = useMemo(() => buildCodeSampleData(verb, path, parameters, operation.requestBody, document), [verb, path, codeSampleLanguage]);
+  const reqData: RequestFormat = useMemo(() => buildCodeSampleData(codeSampleBuildParams), [verb, path, codeSampleLanguage]);
 
   const snippets = useSnippets(codeSampleLanguage, reqData);
 

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -53,6 +53,7 @@ const OperationContent: React.FunctionComponent<OperationProps> = ({verb, path, 
   const parameters = (operation.parameters || []).map(p => deRef(p, document));
 
   const [codeSampleLanguage, setCodeSampleLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[4]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const reqData: RequestFormat = useMemo(() => buildCodeSampleData(verb, path, parameters, operation.requestBody, document), [verb, path, codeSampleLanguage]);
 
   const snippets = useSnippets(codeSampleLanguage, reqData);

--- a/src/hooks/useSnippets.ts
+++ b/src/hooks/useSnippets.ts
@@ -14,11 +14,11 @@ export interface SnippetInfoItem {
 }
 
 export const SnippetItemsArray = [
+  {text: "python", language: "python", highlighter: Language.python, langLibrary: "requests"},
   {text: "go", language: "go", highlighter: Language.go, langLibrary: undefined},
   {text: "java", language: "java", highlighter: Language.java, langLibrary: "asynchttp"},
   {text: "javascript", language: "javascript", highlighter: Language.javascript, langLibrary: "fetch"},
   {text: "node", language: "node", highlighter: Language.javascript, langLibrary: "fetch"},
-  {text: "python", language: "python", highlighter: Language.python, langLibrary: "requests"},
   {text: "c", language: "c", highlighter: Language.cpp, langLibrary: "libcurl"},
   {text: "ruby", language: "ruby", highlighter: Language.ruby, langLibrary: "native"},
   {text: "cURL", language: "shell", highlighter: Language.shell, langLibrary: "curl"},

--- a/src/utils/Snippets.ts
+++ b/src/utils/Snippets.ts
@@ -97,15 +97,16 @@ const inferContentType = (requestBody: OpenAPIV3.ReferenceObject | OpenAPIV3.Req
     if ('content' in value && value.content !== undefined) {
       return Object.keys(value.content)[0]
     }
+    return undefined
   }).filter(val => val !== undefined) as string[]
 
   // giving precedence to the content type mentioned in the requestBody first
   if (requestBodyContentTypes.length > 0) {
     return requestBodyContentTypes[0]
-  } else if (responsesContentTypes.length > 0) {
+  }
+  if (responsesContentTypes.length > 0) {
     return responsesContentTypes[0]
   }
-
   // applicaton/json is the default content type if content type cannot be inferred
   return "application/json"
 }

--- a/src/utils/Snippets.ts
+++ b/src/utils/Snippets.ts
@@ -11,13 +11,13 @@ const getHeaders = (params: DeRefResponse<OpenAPIV3.ParameterObject>[], document
   if (document.components?.securitySchemes) {
     Object.values(document.components?.securitySchemes).forEach(s => {
       const scheme = deRef(s, document)
-      if ("in" in scheme && scheme.in == "header") {
+      if ("in" in scheme && scheme.in === "header") {
         headers.push({name: scheme.name, value: scheme.type})
       }
     });
   }
   params.forEach(param => {
-    if (param.in == "header" && param.required) {
+    if (param.in === "header" && param.required) {
       let val = param.name
       if (param.schema && "type" in param.schema) {
         val = param.schema.type as string
@@ -36,7 +36,7 @@ const getHeaders = (params: DeRefResponse<OpenAPIV3.ParameterObject>[], document
 }
 
 const getQueryParams = (params: DeRefResponse<OpenAPIV3.ParameterObject>[], document: OpenAPIV3.Document): QueryString[] => {
-  const queryParams = params.filter(param => param.in == 'query' && param.required)
+  const queryParams = params.filter(param => param.in === 'query' && param.required)
 
   const paramsWithValue: QueryString[] = queryParams.map(param => {
     const paramName = param.name
@@ -97,6 +97,5 @@ export const buildCodeSampleData = (verb: string, path: string, params: DeRefRes
     postData: getPostData(requestBody, document),
     headersSize: -1,
     bodySize: -1,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   })
 }

--- a/src/utils/Snippets.ts
+++ b/src/utils/Snippets.ts
@@ -1,0 +1,49 @@
+import {OpenAPIV3} from "openapi-types";
+import { DeRefResponse, deRef } from './Openapi';
+import {Request as RequestFormat, Header} from 'har-format'
+
+
+const getHeaders = (params: DeRefResponse<OpenAPIV3.ParameterObject>[], document: OpenAPIV3.Document): Header[] => {
+    const headers: Header[] = []
+    // headers.push({name: "Accept", value: "application/json"})
+    if (document.components?.securitySchemes) {
+        Object.values(document.components?.securitySchemes).forEach(s => {
+            const scheme = deRef(s, document)
+            if ("in" in scheme && scheme.in == "header") {
+                headers.push({name: scheme.name, value: scheme.type})
+            }
+        });
+    }
+    params.forEach(param => {
+        if (param.in == "header" && param.required) {
+            let val = param.name
+            if (param.schema && "type" in param.schema) {
+                val = param.schema.type as string
+            }
+            headers.push({name: param.name, value: val})
+        }
+    })
+
+    // setting 'Content-Type' 'application/json' as a default header
+    const hasContentType = headers.some(header => header.name === 'Content-Type');
+    if (!hasContentType) {
+    headers.push({ name: 'Content-Type', value: 'application/json' });
+    }
+
+    return headers
+  }
+  
+export const buildCodeSampleData = (verb: string, path: string, params: DeRefResponse<OpenAPIV3.ParameterObject>[], document: OpenAPIV3.Document): RequestFormat => {
+    return ({
+        method: verb.toUpperCase(),
+        url: "http://example.com"+path,
+        httpVersion: "HTTP/1.1",
+        cookies: [],
+        headers: getHeaders(params, document),
+        queryString: [], //TODO path params?
+        postData: undefined, //TODO body params
+        headersSize: -1,
+        bodySize: -1,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    })
+}

--- a/src/utils/Snippets.ts
+++ b/src/utils/Snippets.ts
@@ -1,49 +1,102 @@
 import {OpenAPIV3} from "openapi-types";
-import { DeRefResponse, deRef } from './Openapi';
-import {Request as RequestFormat, Header} from 'har-format'
+import { mock } from 'mock-json-schema';
+
+import { DeRefResponse, deRef, recursiveDeRef } from './Openapi';
+import {Request as RequestFormat, Header, QueryString, PostData} from 'har-format'
 
 
 const getHeaders = (params: DeRefResponse<OpenAPIV3.ParameterObject>[], document: OpenAPIV3.Document): Header[] => {
-    const headers: Header[] = []
-    // headers.push({name: "Accept", value: "application/json"})
-    if (document.components?.securitySchemes) {
-        Object.values(document.components?.securitySchemes).forEach(s => {
-            const scheme = deRef(s, document)
-            if ("in" in scheme && scheme.in == "header") {
-                headers.push({name: scheme.name, value: scheme.type})
-            }
-        });
-    }
-    params.forEach(param => {
-        if (param.in == "header" && param.required) {
-            let val = param.name
-            if (param.schema && "type" in param.schema) {
-                val = param.schema.type as string
-            }
-            headers.push({name: param.name, value: val})
-        }
-    })
+  const headers: Header[] = []
 
-    // setting 'Content-Type' 'application/json' as a default header
-    const hasContentType = headers.some(header => header.name === 'Content-Type');
-    if (!hasContentType) {
-    headers.push({ name: 'Content-Type', value: 'application/json' });
-    }
-
-    return headers
+  if (document.components?.securitySchemes) {
+    Object.values(document.components?.securitySchemes).forEach(s => {
+      const scheme = deRef(s, document)
+      if ("in" in scheme && scheme.in == "header") {
+        headers.push({name: scheme.name, value: scheme.type})
+      }
+    });
   }
-  
-export const buildCodeSampleData = (verb: string, path: string, params: DeRefResponse<OpenAPIV3.ParameterObject>[], document: OpenAPIV3.Document): RequestFormat => {
-    return ({
-        method: verb.toUpperCase(),
-        url: "http://example.com"+path,
-        httpVersion: "HTTP/1.1",
-        cookies: [],
-        headers: getHeaders(params, document),
-        queryString: [], //TODO path params?
-        postData: undefined, //TODO body params
-        headersSize: -1,
-        bodySize: -1,
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    })
+  params.forEach(param => {
+    if (param.in == "header" && param.required) {
+      let val = param.name
+      if (param.schema && "type" in param.schema) {
+        val = param.schema.type as string
+      }
+      headers.push({name: param.name, value: val})
+    }
+  })
+
+  // setting 'Content-Type' 'application/json' as a default header
+  const hasContentType = headers.some(header => header.name === 'Content-Type');
+  if (!hasContentType) {
+    headers.push({ name: 'Content-Type', value: 'application/json' });
+  }
+
+  return headers
+}
+
+const getQueryParams = (params: DeRefResponse<OpenAPIV3.ParameterObject>[], document: OpenAPIV3.Document): QueryString[] => {
+  const queryParams = params.filter(param => param.in == 'query' && param.required)
+
+  const paramsWithValue: QueryString[] = queryParams.map(param => {
+    const paramName = param.name
+
+    if (param.example) {
+      return {name: paramName, value: param.example}
+    }
+
+    const paramSchema = param.schema ? deRef(param.schema, document) : undefined
+    if (paramSchema && paramSchema.default) {
+      return {name: paramName, value: paramSchema.default}
+    }
+
+    if (param.examples) {
+      const example = Object.values(param.examples)[0]
+      if ('value' in example) {
+        return {name: paramName, value: example.value}
+      }
+    }
+
+    if (paramSchema && paramSchema.enum) {
+      const enums = paramSchema.enum
+      if (enums.length > 0) {
+        return {name: paramName, value: enums[0]}
+      }
+    }
+
+    return {name: paramName, value: ''}
+  })
+
+  return paramsWithValue
+}
+
+const getPostData = (requestBody: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject | undefined, document: OpenAPIV3.Document): PostData | undefined => {
+  if (!requestBody) {
+    return undefined
+  }
+
+  const deRefResponse = deRef(requestBody, document);
+  if (!deRefResponse.content || !(deRefResponse.content && deRefResponse.content['application/json']?.schema)) {
+    return undefined
+  }
+
+  const jsonSchema = recursiveDeRef(deRefResponse.content['application/json'].schema, document);
+  const requestBodyText = JSON.stringify(mock(jsonSchema), undefined, 2);
+
+  return {mimeType: 'application/json', text: requestBodyText}
+}
+
+export const buildCodeSampleData = (verb: string, path: string, params: DeRefResponse<OpenAPIV3.ParameterObject>[], requestBody: OpenAPIV3.ReferenceObject | OpenAPIV3.RequestBodyObject | undefined, document: OpenAPIV3.Document): RequestFormat => {
+  return ({
+    method: verb.toUpperCase(),
+    url: "http://example.com"+path,
+    httpVersion: "HTTP/1.1",
+    cookies: [],
+    headers: getHeaders(params, document),
+    queryString: getQueryParams(params, document),
+    postData: getPostData(requestBody, document),
+    headersSize: -1,
+    bodySize: -1,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  })
 }


### PR DESCRIPTION
* refactoring
* adding proper `headers`, `query parameters` and `postData` to the code samples component
* setting default language to `python` (imo, `python` looks cleaner than `golang` and more people are familiar with `python` than `golang`)

![image](https://user-images.githubusercontent.com/17099954/229609061-e79d4b81-7fe0-46cb-8b77-a8d5f946b880.png)
