### PR TITLE
Fix no property bug in SchemaDataView

### DIFF
--- a/src/components/APIDoc/SchemaDataView.tsx
+++ b/src/components/APIDoc/SchemaDataView.tsx
@@ -128,7 +128,13 @@ const getTreeViewData = (schemaName: string, schema: DeRefResponse<OpenAPIV3.Arr
   if (!schema.properties) {
     return [{name: "schema undefined"}] as TreeViewDataItem[]
   }
-  const schemaData = Object.entries(schema.properties).map(([key, value]) => {
+
+  const schemaKeyValArray = Object.entries(schema.properties)
+  if (schemaKeyValArray.length < 1) {
+    return [{name: "schema undefined"}] as TreeViewDataItem[]
+  }
+
+  const schemaData = schemaKeyValArray.map(([key, value]) => {
     let propertyType = "object"
     let children: TreeViewDataItem[] | undefined = undefined
 

--- a/src/components/APIDoc/SchemaDataView.tsx
+++ b/src/components/APIDoc/SchemaDataView.tsx
@@ -131,7 +131,7 @@ const getTreeViewData = (schemaName: string, schema: DeRefResponse<OpenAPIV3.Arr
 
   const schemaKeyValArray = Object.entries(schema.properties)
   if (schemaKeyValArray.length < 1) {
-    return [{name: "schema undefined"}] as TreeViewDataItem[]
+    return [{name: "Any data"}] as TreeViewDataItem[]
   }
 
   const schemaData = schemaKeyValArray.map(([key, value]) => {


### PR DESCRIPTION
Handles no property keys edge case in the SchemaDataView component

```
"NamespaceRelatedField": {
        "type": "object",
        "description": "<redacted>",
        "properties": {}
      },
```

Check out the `NamespaceRelatedField` field schema of the automation hub API.

The app will crash because we are not handling the edge case where the `properties` key is mentioned in the schema but  its value is `{}`. This PR is to cover that edge case.