### PR TITLE
RHCLOUD-24941 Add links to other types within the document

### DIFF
--- a/src/components/APIDoc/ParameterView.tsx
+++ b/src/components/APIDoc/ParameterView.tsx
@@ -2,8 +2,7 @@ import React from "react"
 import { OpenAPIV3 } from 'openapi-types';
 import {Flex, FlexItem, Text, TextContent, TextVariants} from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Thead, Tr } from "@patternfly/react-table";
-import { deRef } from "../../utils/Openapi";
-
+import {SchemaType} from "./SchemaType";
 
 interface ParameterViewProps {
     title: string;
@@ -37,7 +36,7 @@ export const ParameterView: React.FunctionComponent<ParameterViewProps> = ({titl
                             </FlexItem>
                         </Flex>
                     </Td>
-                    <Td>{getType(p.schema, document)}</Td>
+                    <Td><SchemaType schema={p.schema} document={document} writeEnums/></Td>
                     <Td>{p.description}</Td>
                 </Tr>
                 )))}
@@ -45,19 +44,4 @@ export const ParameterView: React.FunctionComponent<ParameterViewProps> = ({titl
             </TableComposable>
         </>
     )
-}
-
-
-const getType = (schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined, document: OpenAPIV3.Document) => {
-    if (schema === undefined) {
-        return 'Unknown';
-    }
-
-    const dSchema = deRef(schema, document);
-
-    if (dSchema.enum) {
-        return dSchema.enum.join(' | ');
-    }
-
-    return dSchema.type;
 }

--- a/src/components/APIDoc/ResponseView.tsx
+++ b/src/components/APIDoc/ResponseView.tsx
@@ -9,7 +9,7 @@ import {
 } from "@patternfly/react-core";
 import {ExpandableRowContent, TableComposable, Tbody, Td, Th, Thead, Tr} from "@patternfly/react-table";
 import {ExampleResponse} from "./ExampleResponse";
-
+import {SchemaType} from "./SchemaType";
 
 interface ResponseViewProps {
   responses: OpenAPIV3.ResponsesObject;
@@ -23,7 +23,7 @@ export const ResponseView: React.FunctionComponent<ResponseViewProps> = ({respon
     return isExpanding ? [...otherExpandedRowNames, code] : otherExpandedRowNames;
     });
   const isCodeExpanded = (code: string) => expandedCodes.includes(code);
-  
+
   const responseMap = Object.entries(responses ?? {});
 
   const responseExamples = React.useMemo(() => {
@@ -33,7 +33,7 @@ export const ResponseView: React.FunctionComponent<ResponseViewProps> = ({respon
 
     return undefined;
   }, [ responses, document]);
-  
+
   return (
     <>
       { responseMap.length > 0 && <>
@@ -75,7 +75,7 @@ export const ResponseView: React.FunctionComponent<ResponseViewProps> = ({respon
         })}
         </Tbody>
         </TableComposable>
-      </> }           
+      </> }
     </>
   )
 }
@@ -86,6 +86,6 @@ const getResponseSchema = (response: OpenAPIV3.ResponseObject, document: OpenAPI
       return 'None';
   }
 
-  // Previously filtered for undefined schemas
-  return deRef(contents[0].schema!, document).deRefData?.name;
+  // Todo we should try to display all available types
+  return <SchemaType document={document} schema={contents[0].schema!} />;
 }

--- a/src/components/APIDoc/SchemaPropertyView.tsx
+++ b/src/components/APIDoc/SchemaPropertyView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {ReactNode} from 'react';
 import { Text, TextContent, TextVariants, Flex, FlexItem, Label, LabelGroup } from '@patternfly/react-core';
 import { OpenAPIV3 } from 'openapi-types';
 
@@ -6,7 +6,7 @@ import { OpenAPIV3 } from 'openapi-types';
 interface PropertyViewComponentProps {
   propSchema?: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject;
   propName: string;
-  propertyType: string;
+  propertyType: ReactNode;
   required: boolean | undefined;
 }
 

--- a/src/components/APIDoc/SchemaType.tsx
+++ b/src/components/APIDoc/SchemaType.tsx
@@ -1,0 +1,42 @@
+import {FunctionComponent} from "react";
+import {OpenAPIV3} from "openapi-types";
+import {deRef} from "../../utils/Openapi";
+import {JumpLink} from "../JumpLink/JumpLink";
+import {getSchemaId} from "../../utils/OpenapiHtmlIds";
+
+export interface SchemaTypeProps {
+    document: OpenAPIV3.Document;
+    schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined;
+    writeEnums?: boolean;
+}
+
+export const SchemaType: FunctionComponent<SchemaTypeProps> = ({schema, document, writeEnums}) => {
+    if (!schema) {
+        return <span>Unknown</span>;
+    }
+
+    const dSchema = deRef(schema, document);
+
+    if (dSchema.deRefData?.name) {
+        return <JumpLink id={getSchemaId(dSchema.deRefData.name)}>{dSchema.deRefData.name}</JumpLink>;
+    }
+
+    if (dSchema.type === undefined) {
+        return <span>Unknown</span>;
+    }
+
+
+    // Enums are applied as modifiers else where - we need to make this behavior consistent
+    if (writeEnums && dSchema.enum) {
+        return <span>{dSchema.enum.join(' | ')}</span>;
+    }
+
+    if (dSchema.type === 'array') {
+
+        // This will get "funny" (not really) If the type is inline - we should probably preprocess and create custom
+        // types if that happens. or think of another way of display an Array of something that is not name
+        return <span>Array&lt;<SchemaType schema={dSchema.items} document={document} />&gt;</span>;
+    }
+
+    return <span>{dSchema.type}</span>
+}

--- a/src/components/JumpLink/JumpLink.tsx
+++ b/src/components/JumpLink/JumpLink.tsx
@@ -1,0 +1,12 @@
+import {FunctionComponent, PropsWithChildren} from 'react';
+
+
+interface JumpLinkProps {
+    id: string;
+}
+
+export const JumpLink: FunctionComponent<PropsWithChildren<JumpLinkProps>> = ({id, children}) => {
+    return <a href={`#${id}`}>
+        {children}
+    </a>;
+};

--- a/src/utils/OpenapiHtmlIds.ts
+++ b/src/utils/OpenapiHtmlIds.ts
@@ -3,3 +3,4 @@ export const getOperationId = () => 'content-operations';
 export const getOperationGroupId = (groupId: string) => `content-operations-group-${groupId}`;
 export const getUngroupedOperationsId = () => `content-operations-ungrouped`;
 export const getSchemasId = () => 'content-schemas';
+export const getSchemaId = (schema: string) => `schema-${schema}`;


### PR DESCRIPTION
The logic to determine what type is a schema is started to get mixed all over the place. 

If we want to integrate other schemas I feel we should start building an adhoc format to suit our needs - preprocessing the openapi3 (and others to follow) into something easier to digest by the site itself. This format could be in the future the one provided by our backend (if we decide to have any).

Right now I'm adding links but there still some inconsistencies around (e.g. the enums are displayed as "modifiers" in the schemas, and directly in the top schema.
Some other notes, a schema can potentially have `allOf`, `oneOf` and `anyOf` at the same time.

![gif_2023-04-13T13:00:59](https://user-images.githubusercontent.com/3845764/231857868-58b12c99-491e-4edf-b15b-3183dd05296e.gif)
