### PR TITLE
[ RHCLOUD-24945, RHCLOUD-25156 ] Hide example when an operation has no content

### DIFF
--- a/src/components/APIDoc/ResponseView.tsx
+++ b/src/components/APIDoc/ResponseView.tsx
@@ -52,25 +52,33 @@ export const ResponseView: React.FunctionComponent<ResponseViewProps> = ({respon
         <Tbody>
         {responseMap.map(([code, response],rowIndex) => {
           const dResponse = deRef(response, document);
+
+          let expandInfo;
+          if (responseExamples && responseExamples[code]?.length > 0) {
+            expandInfo = {
+              rowIndex,
+              isExpanded: isCodeExpanded(code),
+              onToggle: () => setCodeExpanded(code, !isCodeExpanded(code)),
+              expandId: 'response-code-expanded'
+            }
+          }
+
           return <>
             <Tr key={code} >
-              <Td expand={{
-                  rowIndex,
-                  isExpanded: isCodeExpanded(code),
-                  onToggle: () => setCodeExpanded(code, !isCodeExpanded(code)),
-                  expandId: 'response-code-exanded'
-              }}/>
+              <Td expand={expandInfo}/>
               <Td>{code}</Td>
               <Td>{dResponse.description}</Td>
               <Td>{getResponseSchema(dResponse, document)}</Td>
             </Tr>
-            <Tr isExpanded={isCodeExpanded(code)}>
+            {
+              expandInfo && <Tr isExpanded={isCodeExpanded(code)}>
               <Td noPadding={true} colSpan={4}>
                   <ExpandableRowContent>
-                    {responseExamples && <ExampleResponse response={code in responseExamples ? responseExamples[code] : ""}/>}
+                    {responseExamples && <ExampleResponse response={responseExamples[code]}/>}
                   </ExpandableRowContent>
               </Td>
             </Tr>
+            }
           </>;
         })}
         </Tbody>


### PR DESCRIPTION
SPUR action item - The user shouldn’t be able to expand a row item that has no content. Rows without content shouldn’t have an expand arrow. 

Before:
![image](https://user-images.githubusercontent.com/17099954/232134838-7d362f11-edb2-4f5d-996c-5a6ca7d1c56a.png)

After:
![image](https://user-images.githubusercontent.com/17099954/232134919-5737dfee-821c-447d-9a76-04aea403f70d.png)
