### PR TITLE
Managing state of code sample language [RHCLOUD-24400]

### DIFF
--- a/src/components/APIDoc/CodeBlockDropdown.tsx
+++ b/src/components/APIDoc/CodeBlockDropdown.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 
 import { SnippetInfoItem, SnippetItemsArray } from '../../hooks/useSnippets';
+import { useSetLanguage, useLanguage } from '../../utils/LanguageContext';
 
 
-export interface CodeBlockDropdownProps {
-  language: SnippetInfoItem;
-  setLanguage: React.Dispatch<React.SetStateAction<SnippetInfoItem>>;
-}
+export const CodeBlockDropdown: React.FunctionComponent = () => {
+  const language = useLanguage();
+  const setLanguage = useSetLanguage();
 
-export const CodeBlockDropdown: React.FunctionComponent<CodeBlockDropdownProps> = ({ language, setLanguage }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [selected, setSelected] = React.useState(language.text);
 

--- a/src/components/APIDoc/CodeBlockDropdown.tsx
+++ b/src/components/APIDoc/CodeBlockDropdown.tsx
@@ -10,7 +10,6 @@ export const CodeBlockDropdown: React.FunctionComponent = () => {
   const setLanguage = useSetLanguage();
 
   const [isOpen, setIsOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState(language.text);
 
   const onToggle = (isOpen: boolean) => {
     setIsOpen(isOpen);
@@ -27,7 +26,6 @@ export const CodeBlockDropdown: React.FunctionComponent = () => {
   };
 
   const onDropdownSelect = (event: any, item: SnippetInfoItem) => {
-    setSelected(item.text);
     setLanguage(item);
   }
 
@@ -36,7 +34,7 @@ export const CodeBlockDropdown: React.FunctionComponent = () => {
       onSelect={onSelect}
       toggle={
         <DropdownToggle id="toggle-basic" onToggle={onToggle}>
-          {selected}
+          {language.text}
         </DropdownToggle>
       }
       isOpen={isOpen}

--- a/src/components/APIDoc/CodeSamples.tsx
+++ b/src/components/APIDoc/CodeSamples.tsx
@@ -4,16 +4,16 @@ import { CodeEditor } from '@patternfly/react-code-editor';
 
 import { SnippetInfoItem, } from '../../hooks/useSnippets';
 import { CodeBlockDropdown } from './CodeBlockDropdown';
-
+import { useLanguage } from '../../utils/LanguageContext';
 
 interface CodeSampleProps {
   codesnippet: string;
-  language: SnippetInfoItem;
-  setLanguage: React.Dispatch<React.SetStateAction<SnippetInfoItem>>;
 }
 
-export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({ codesnippet, language, setLanguage }) => {
+export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({ codesnippet }) => {
     const [copied, setCopied] = useState<boolean>(false);
+
+    const language = useLanguage();
 
     if (!codesnippet) {
       return null; // Return null if there are no code samples; Without this logic the code samples initially shows up as selected
@@ -34,7 +34,7 @@ export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({ codesnip
           <FlexItem className="pf-u-flex-grow-1 pf-u-pl-lg">
           </FlexItem>
           <FlexItem align={{ default: 'alignRight' }}>
-            <CodeBlockDropdown language={language} setLanguage={setLanguage}/>
+            <CodeBlockDropdown />
             <ClipboardCopyButton
               id="basic-copy-button"
               textId="code-content"

--- a/src/components/APIDoc/CodeSamples.tsx
+++ b/src/components/APIDoc/CodeSamples.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Card, CardBody, CardHeader, ClipboardCopyButton, FlexItem } from '@patternfly/react-core';
 import { CodeEditor } from '@patternfly/react-code-editor';
 
-import { SnippetInfoItem, } from '../../hooks/useSnippets';
 import { CodeBlockDropdown } from './CodeBlockDropdown';
 import { useLanguage } from '../../utils/LanguageContext';
 

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -20,6 +20,7 @@ import { ResponseView } from './ResponseView';
 import {Request as RequestFormat} from 'har-format'
 
 import { SnippetInfoItem, SnippetItemsArray, useSnippets } from '../../hooks/useSnippets';
+import { useLanguage } from '../../utils/LanguageContext';
 
 export interface OperationProps {
   verb: string;
@@ -55,7 +56,8 @@ const OperationContent: React.FunctionComponent<OperationProps> = ({verb, path, 
   const queryParameters = parameters.filter(p => p.in === "query");
   const pathParameters = parameters.filter(p => p.in === "path");
 
-  const [codeSampleLanguage, setCodeSampleLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[0]);
+  const codeSampleLanguage = useLanguage();
+
   const codeSampleBuildParams: BuildCodeSampleDataParams = {
     verb: verb,
     path: path,
@@ -93,7 +95,7 @@ const OperationContent: React.FunctionComponent<OperationProps> = ({verb, path, 
         <ResponseView responses={operation.responses} document={document} />
       </GridItem>
       <GridItem className="pf-m-12-col pf-m-5-col-on-xl pf-u-mt-md-on-xl pf-u-ml-sm-on-xl">
-        <CodeSamples codesnippet={snippets} language={codeSampleLanguage} setLanguage={setCodeSampleLanguage}/>
+        <CodeSamples codesnippet={snippets}/>
       </GridItem>
     </Grid>
   );

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -19,7 +19,7 @@ import { ResponseView } from './ResponseView';
 
 import {Request as RequestFormat} from 'har-format'
 
-import { SnippetInfoItem, SnippetItemsArray, useSnippets } from '../../hooks/useSnippets';
+import { useSnippets } from '../../hooks/useSnippets';
 import { useLanguage } from '../../utils/LanguageContext';
 
 export interface OperationProps {

--- a/src/components/APIDoc/Operations.tsx
+++ b/src/components/APIDoc/Operations.tsx
@@ -2,7 +2,9 @@ import {FunctionComponent, PropsWithChildren} from "react";
 import {Accordion} from "@patternfly/react-core";
 
 export const Operations: FunctionComponent<PropsWithChildren> = ({children}) => {
-    return <Accordion className="apid-c-accordion-operations" isBordered>
-        {children}
-    </Accordion>;
+    return(
+        <Accordion className="apid-c-accordion-operations" isBordered>
+            {children}
+        </Accordion>
+    )
 }

--- a/src/pages/APIPage.tsx
+++ b/src/pages/APIPage.tsx
@@ -22,6 +22,8 @@ import {useGroupedOperations} from "../components/APIDoc/hooks/useGroupedOperati
 import {SidebarApiSections} from "../components/SideBar/SidebarApiSections";
 import {fromApiLabels} from "../utils/DevelopersRedHatTaxonomy";
 import {Config} from "../config";
+import { LanguageProvider } from '../utils/LanguageContext';
+
 
 type ApiState = {
     isLoading: true;
@@ -66,6 +68,7 @@ export const APIPage: FunctionComponent = () => {
     const taxonomyData = fromApiLabels(selectedApi.tags);
 
     return <>
+        <LanguageProvider>
         <Helmet>
             <title>{selectedApi.displayName} | {Config.title} </title>
             <meta name="rhd:node-type" content="api_docs" />
@@ -96,5 +99,6 @@ export const APIPage: FunctionComponent = () => {
             </SidebarContent>
           </Sidebar>
         </Page>
+        </LanguageProvider>
     </>;
 };

--- a/src/pages/APIPage.tsx
+++ b/src/pages/APIPage.tsx
@@ -85,11 +85,11 @@ export const APIPage: FunctionComponent = () => {
             </Breadcrumb>
           </PageSection>
           <Sidebar>
-            <SidebarPanel className="pf-u-p-lg">
+            <SidebarPanel className="pf-u-p-lg" style={{ height: '92vh', overflow: 'auto' }} >
                 <SidebarApiSections openapi={openapi} groupedOperations={groupedOperations} />
             </SidebarPanel>
 
-            <SidebarContent>
+            <SidebarContent style={{ height: '92vh', overflow: 'auto' }} >
               { (apiState.isLoading || !apiState.api || groupedOperations.loading) ?
                   <Bullseye><Spinner /></Bullseye> :
                   <ApiDoc openapi={apiState.api} groupedOperations={groupedOperations.value} /> }

--- a/src/utils/LanguageContext.tsx
+++ b/src/utils/LanguageContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+
+import { SnippetInfoItem, SnippetItemsArray } from '../hooks/useSnippets';
+
+
+type LanguageContextType = {
+  language: SnippetInfoItem;
+  handleChangeLanguage: (newLanguage: SnippetInfoItem) => void;
+};
+
+const LanguageContext = createContext<LanguageContextType>({
+  language: SnippetItemsArray[0],
+  handleChangeLanguage: () => {},
+});
+
+type LanguageProviderProps = {
+  children: ReactNode;
+};
+
+export const LanguageProvider = ({ children }: LanguageProviderProps) => {
+  const [language, setLanguage] = useState<SnippetInfoItem>(SnippetItemsArray[0]);
+
+  function handleChangeLanguage(newLanguage: SnippetInfoItem) {
+    setLanguage(newLanguage);
+  }
+
+  return (
+    <LanguageContext.Provider value={{ language, handleChangeLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const { language } = useContext(LanguageContext);
+  return language;
+};
+
+export const useSetLanguage = () => {
+  const { handleChangeLanguage } = useContext(LanguageContext);
+  return handleChangeLanguage;
+};


### PR DESCRIPTION
Whenever user switches to a specific programming language in one of the `codesample` component, it switches to that programming language for all `codesample` components in that doc.