### PR TITLE
RHCLOUD-25826 Fix Typos on Tags/ Filtering

### DIFF
--- a/packages/common/config/apis.ts
+++ b/packages/common/config/apis.ts
@@ -100,9 +100,9 @@ export const apiLabelsMap: Record<string, Readonly<APILabel>> = {
       product: undefined,
     },
   },
-  "identify-and-access-management": {
-    id: "identify-and-access-management",
-    name: "Identify and Access Management",
+  "identity-and-access-management": {
+    id: "identity-and-access-management",
+    name: "Identity and Access Management",
     type: "use-case",
     devRedHatTaxonomy: {
       topic: undefined,
@@ -120,7 +120,7 @@ export const apiLabelsMap: Record<string, Readonly<APILabel>> = {
   },
   openshift: {
     id: "openshift",
-    name: "Openshift",
+    name: "OpenShift",
     type: "platform",
     devRedHatTaxonomy: {
       topic: undefined,
@@ -427,7 +427,7 @@ export const apiConfigurations: ReadonlyArray<Readonly<APIConfiguration>> = [
       import(
         "./apis/hcc-insights/rbac/openapi.json"
       ) as unknown as Promise<OpenAPIV3.Document>,
-    tags: [apiLabelsMap["identify-and-access-management"]],
+    tags: [apiLabelsMap["identity-and-access-management"]],
   },
   {
     id: "sources",
@@ -439,7 +439,7 @@ export const apiConfigurations: ReadonlyArray<Readonly<APIConfiguration>> = [
       import(
         "./apis/hcc-insights/sources/openapi.json"
       ) as unknown as Promise<OpenAPIV3.Document>,
-    tags: [apiLabelsMap["identify-and-access-management"]],
+    tags: [apiLabelsMap["identity-and-access-management"]],
   },
   {
     id: "rhsm-subscriptions",

--- a/packages/discovery/Discovery.yml
+++ b/packages/discovery/Discovery.yml
@@ -208,14 +208,14 @@ apis:
         url: https://console.redhat.com/api/rbac/v1/openapi.json
         apiType: openapi-v3
         tags:
-          - identify-and-access-management
+          - identity-and-access-management
       - id: sources
         name: Sources
         description: Sources API
         url: https://console.redhat.com/api/sources/v3.1/openapi.json
         apiType: openapi-v3
         tags:
-          - identify-and-access-management
+          - identity-and-access-management
       - id: rhsm-subscriptions
         name: Subscriptions
         description: REST interface for the rhsm-subscriptions service
@@ -466,14 +466,14 @@ tags:
   - id: inventories
     name: Inventories
     type: service
-  - id: identify-and-access-management
-    name: Identify and Access Management
+  - id: identity-and-access-management
+    name: Identity and Access Management
     type: use-case
   - id: observe
     name: Observe
     type: use-case
   - id: openshift
-    name: Openshift
+    name: OpenShift
     type: platform
   - id: rhel
     name: RHEL


### PR DESCRIPTION
Correct the two following typos that are showing up in the tags/ filtering:

- Openshift -> OpenShift
- Identify and access... -> Identity and Access...