### PR TITLE
[RHCLOUD-25148] Fix individual doc operation auto scroll up issue

### DIFF
--- a/src/components/APIDoc/CodeBlockDropdown.tsx
+++ b/src/components/APIDoc/CodeBlockDropdown.tsx
@@ -15,14 +15,8 @@ export const CodeBlockDropdown: React.FunctionComponent = () => {
     setIsOpen(isOpen);
   };
 
-  const onFocus = () => {
-    const element = document.getElementById('toggle-basic');
-    element?.focus();
-  };
-
   const onSelect = (event: any) => {
     setIsOpen(false);
-    onFocus();
   };
 
   const onDropdownSelect = (event: any, item: SnippetInfoItem) => {
@@ -33,7 +27,7 @@ export const CodeBlockDropdown: React.FunctionComponent = () => {
     <Dropdown
       onSelect={onSelect}
       toggle={
-        <DropdownToggle id="toggle-basic" onToggle={onToggle}>
+        <DropdownToggle onToggle={onToggle}>
           {language.text}
         </DropdownToggle>
       }


### PR DESCRIPTION
# Fix individual doc operation auto scroll up issue
[RHCLOUD-25148](https://issues.redhat.com/secure/RapidBoard.jspa?rapidView=7827&projectKey=RHCLOUD&view=detail&selectedIssue=RHCLOUD-25148)
- Fixed auto-scroll up problem by removing `onFocus`, which focusing the first element matching the `id` of `toggle-basic`.
- Removed usage of `toggle-basic` as `id`, because it was being reused in all `CodeBlockDropdown` components. `id` values should be unique to avoid confusion. The `getElementById` function was inadvertently referencing the first occurrence of `toggle-basic` on the page.