### PR TITLE
Improve perception that "Show more" won't show only one line more

### DIFF
--- a/src/components/APIDoc/ExampleResponse.tsx
+++ b/src/components/APIDoc/ExampleResponse.tsx
@@ -8,8 +8,7 @@ export interface ExampleResponseProps {
 
 export const ExampleResponse: React.FunctionComponent<ExampleResponseProps> = ({response}) => {
     const codeByLines = response.split('\n');
-    const first5Lines = codeByLines.slice(0, 5).join('\n');
-    const remaining = codeByLines.slice(5, codeByLines.length).join('\n');
+    const showMore = codeByLines.length > 8;
     const id = `example-response-${stringHash(response)}`;
 
     const [isExpanded, setExpanded] = React.useState(false);
@@ -18,12 +17,16 @@ export const ExampleResponse: React.FunctionComponent<ExampleResponseProps> = ({
     return <>
         <CodeBlock>
             <CodeBlockCode>
-                {first5Lines}
-                {remaining.length > 0 && <ExpandableSection isExpanded={isExpanded} isDetached contentId={id}>
-                    {remaining}
-                </ExpandableSection>}
+                {showMore ? <>
+                    {codeByLines.slice(0, 5).join('\n')}
+                    <ExpandableSection isExpanded={isExpanded} isDetached contentId={id}>
+                        {codeByLines.slice(5).join('\n')}
+                    </ExpandableSection>
+                </> : <>
+                    {codeByLines.join('\n')}
+                </>}
             </CodeBlockCode>
-            {remaining.length > 0 && <ExpandableSectionToggle
+            {showMore && <ExpandableSectionToggle
                 isExpanded={isExpanded}
                 onToggle={onToggle}
                 contentId="code-block-expand"


### PR DESCRIPTION
 - Show more will only appear if the example has over 8 lines
 - The cutoff will happen after line 5, showing at least 3 more lines

Long examples remain the same

## Short example

Before:

![screenshot_2023-06-26T10:49:21](https://github.com/RedHatInsights/api-documentation-frontend/assets/3845764/326d7e24-a820-4f6e-9962-cdd74aaff203)


![screenshot_2023-06-26T10:49:26](https://github.com/RedHatInsights/api-documentation-frontend/assets/3845764/b52c2dc2-2adb-477e-ab68-da0083d03316)

After:

![screenshot_2023-06-26T10:45:49](https://github.com/RedHatInsights/api-documentation-frontend/assets/3845764/275a4b26-3bac-4772-a1a8-762efbe1b032)
