### PR TITLE
Remove references to "API Docs"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,12 +34,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class=“rhd-m-max-width-xl”>
-      <esi:include src="https://developers.redhat.com/api/chrome/rh-universal-nav-header?f=type~api_catalog" />
-      <!--#include virtual="/.include/chrome/rh-universal-nav-header/rh-universal-nav-header.html" -->
       <div id="root"></div>
-      <esi:include src=“https://developers.redhat.com/api/chrome/rh-unified-footer” />
-      <!--#include virtual="/.include/chrome/rh-unified-footer/rh-unified-footer.html" -->
-
       <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
       <link rel="stylesheet" href="/modules/contrib/red_hat_universal_navigation/dist/@cpelements/pfe-navigation/dist/pfe-navigation--lightdom.css" />

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,9 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class=“rhd-m-max-width-xl”>
+      <!--#include virtual="/.include/chrome/rh-universal-nav-header/rh-universal-nav-header.html" -->
       <div id="root"></div>
+      <!--#include virtual="/.include/chrome/rh-unified-footer/rh-unified-footer.html" -->
       <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
       <link rel="stylesheet" href="/modules/contrib/red_hat_universal_navigation/dist/@cpelements/pfe-navigation/dist/pfe-navigation--lightdom.css" />

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
       }
       </script>
 
-    <title>API Docs</title>
+    <title>API Catalog</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class=“rhd-m-max-width-xl”>
-      <esi:include src=“https://developers.redhat.com/api/chrome/rh-universal-nav-header” />
+      <esi:include src="https://developers.redhat.com/api/chrome/rh-universal-nav-header?f=type~api_catalog" />
       <!--#include virtual="/.include/chrome/rh-universal-nav-header/rh-universal-nav-header.html" -->
       <div id="root"></div>
       <esi:include src=“https://developers.redhat.com/api/chrome/rh-unified-footer” />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "API Docs",
-  "name": "API Docs",
+  "short_name": "API Catalog",
+  "name": "API Catalog",
   "icons": [],
   "start_url": "%PUBLIC_URL%",
   "display": "standalone",

--- a/src/pages/APIPage.tsx
+++ b/src/pages/APIPage.tsx
@@ -71,7 +71,7 @@ export const APIPage: FunctionComponent = () => {
         <LanguageProvider>
         <Helmet>
             <title>{selectedApi.displayName} | {Config.title} </title>
-            <meta name="rhd:node-type" content="api_docs" />
+            <meta name="rhd:node-type" content="api_catalog" />
             <meta name="description" content={selectedApi.description} />
             { taxonomyData.map(t => (
                 <meta name={`rhd:taxonomy-${t.type}`} content={t.value} />


### PR DESCRIPTION
[[RHCLOUD-25827](https://issues.redhat.com/browse/RHCLOUD-25827)]
Replaced API Docs with API Catalog in the following:
- meta `rhd:node-type` tag
- page title
- name in manifest.json