### PR TITLE
Fix Patch v3 API path

### DIFF
--- a/packages/discovery/Discovery.yml
+++ b/packages/discovery/Discovery.yml
@@ -148,7 +148,7 @@ apis:
       - id: patch
         name: Patch
         description: API of the Patch application on console.redhat.com
-        url: https://console.redhat.com/api/patch/v2/openapi.json
+        url: https://console.redhat.com/api/patch/v3/openapi.json
         apiType: openapi-v3
         icon: insights
         tags:


### PR DESCRIPTION
[[RHCLOUD-25982](https://issues.redhat.com/browse/RHCLOUD-25982)]

Update Patch API to correct v3 URL (https://console.redhat.com/api/patch/v3/openapi.json)