### PR TITLE
Fix card link color

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -33,7 +33,7 @@ export const Card: FunctionComponent<PropsWithChildren<CardProps>> = ({apiId, di
     }
   }
 
-  return <Link to={to} onClick={onCardClick} style={{textDecoration: 'none'}}>
+  return <Link to={to} onClick={onCardClick} style={{textDecoration: 'none'}} className="pf-u-color-100">
     <PFCard
       role="link"
       isSelectableRaised


### PR DESCRIPTION
Fix the styling for links from turning the card header text blue

![image](https://github.com/RedHatInsights/api-documentation-frontend/assets/3845764/e68f154f-bbf4-4f37-8e89-c7767038f8dc)
