### PR TITLE
Using env var to determine base url for canonical json

### DIFF
--- a/packages/sitemap/src/collector.ts
+++ b/packages/sitemap/src/collector.ts
@@ -1,7 +1,5 @@
 import {APIConfiguration} from "@apidocs/common";
 
-const APIBASEURL = "https://developers.redhat.com/api-catalog"
-
 type Document = {
     solr_command: string;
     content_type: string;
@@ -16,7 +14,7 @@ type CanonicalFormat = {
     documents: Array<Document>;
 }
 
-const getDocuments = (config: ReadonlyArray<Readonly<APIConfiguration>>): Promise<Array<Document>> => Promise.all(config.map(
+const getDocuments = (config: ReadonlyArray<Readonly<APIConfiguration>>, baseurl: string): Promise<Array<Document>> => Promise.all(config.map(
     async (api) => {
         const contentSummaries = await api.getApiContent().then((content) => {
             const paths = content.openapi.paths
@@ -36,7 +34,7 @@ const getDocuments = (config: ReadonlyArray<Readonly<APIConfiguration>>): Promis
             solr_command: "index",
             content_type: "documentation",
             id: api.id,
-            uri: `${APIBASEURL}/api/${api.id}`,
+            uri: `${baseurl}/api/${api.id}`,
             name: `${api.displayName} | API Catalog and Documentation`,
             description: api.description,
             content_summaries: contentSummaries
@@ -44,8 +42,8 @@ const getDocuments = (config: ReadonlyArray<Readonly<APIConfiguration>>): Promis
     )
 )
 
-export const collector = async (config: ReadonlyArray<Readonly<APIConfiguration>>): Promise<string> => {
-    const documents = await getDocuments(config)
+export const collector = async (config: ReadonlyArray<Readonly<APIConfiguration>>, baseurl: string): Promise<string> => {
+    const documents = await getDocuments(config, baseurl)
 
     const collection: CanonicalFormat = {
         data_source: "dev_api_catalog",

--- a/packages/sitemap/src/main.ts
+++ b/packages/sitemap/src/main.ts
@@ -48,7 +48,7 @@ export const execute = async (options: Options) => {
         urls: urlItems
     });
 
-    const collectorContent = await collector(apiConfigurations)
+    const collectorContent = await collector(apiConfigurations, options.baseUri)
     writeCollectorContent(collectorContent, options)
 }
 


### PR DESCRIPTION
Using the `SITEMAP_BASE_URL` env var to determine the base url for the canonical json doc