### PR TITLE
Fix Request body schema

### DIFF
--- a/src/components/APIDoc/RequestBodyView.tsx
+++ b/src/components/APIDoc/RequestBodyView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { OpenAPIV3 } from "openapi-types";
-import { deRef, DeRefResponse } from "../../utils/Openapi";
+import { DeRefResponse } from "../../utils/Openapi";
 import {
   Flex,
   FlexItem,


### PR DESCRIPTION
Schemas on API POST/PUT requests are now linked/clickable
Had to change the way that deref was being called for the empty ref schemas 
The request body schema now should link to the bottom schemas 

- RHCLOUD-27270
