### PR TITLE
[RHCLOUD-26197] Using markdown for a few descriptions

### DIFF
--- a/src/components/APIDoc/ApiDoc.tsx
+++ b/src/components/APIDoc/ApiDoc.tsx
@@ -10,6 +10,7 @@ import {getAuthenticationId, getOperationId, getSchemasId} from "../../utils/Ope
 import {getTitleWithVersion} from "../../utils/OpenapiSelectors";
 import {APIContent, ExtraAPIContent} from "@apidocs/common";
 import {DocumentContent} from "../DocumentContent/DocumentContent";
+import ReactMarkdown from "react-markdown";
 
 interface ApiDocProps {
     apiContent: APIContent;
@@ -28,9 +29,12 @@ export const ApiDoc: FunctionComponent<ApiDocProps> = props => {
           <Text component={TextVariants.h1}>
             {getTitleWithVersion(openapi)}
           </Text>
-          <Text component={TextVariants.p} className="pf-u-pb-md">
-            { openapi.info.description }
-          </Text>
+          {
+            openapi.info.description &&
+            <Text component={TextVariants.p} className="pf-u-pb-md">
+              <ReactMarkdown>{ openapi.info.description }</ReactMarkdown>
+            </Text>
+          }
         </TextContent>
 
         { openapi.servers && (

--- a/src/components/APIDoc/Operation.tsx
+++ b/src/components/APIDoc/Operation.tsx
@@ -17,6 +17,7 @@ import {
   AccordionContent,
   Label,
 } from "@patternfly/react-core";
+import ReactMarkdown from "react-markdown";
 
 import { ParameterView } from "./ParameterView";
 import { CodeSamples } from "./CodeSamples";
@@ -112,7 +113,12 @@ const OperationContent: React.FunctionComponent<OperationProps> = ({
     <Grid className="pf-u-mt-sm" hasGutter>
       <GridItem className="pf-m-12-col">
         <TextContent>
-          <Text component={TextVariants.p}>{operation.description}</Text>
+          {
+            operation.description &&
+            <Text component={TextVariants.p}>
+              <ReactMarkdown>{operation.description}</ReactMarkdown>
+            </Text>
+          }
         </TextContent>
       </GridItem>
       <GridItem className="pf-m-12-col pf-m-7-col-on-xl">

--- a/src/components/APIDoc/SecurityScheme.tsx
+++ b/src/components/APIDoc/SecurityScheme.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {OpenAPIV3} from "openapi-types";
+import ReactMarkdown from "react-markdown";
 
 export interface SecuritySchemesProps {
     securityScheme: OpenAPIV3.SecuritySchemeObject;
@@ -24,7 +25,12 @@ const SecuritySchemeHttp: React.FunctionComponent<OpenAPIV3.HttpSecurityScheme> 
     return <>
         <span>HTTP Authentication, scheme: {http.scheme}</span>
         <br/>
-        <span>{http.description}</span>
+        {
+            http.description &&
+            <span>
+                <ReactMarkdown>{http.description}</ReactMarkdown>
+            </span>
+        }
     </>;
 }
 
@@ -36,6 +42,11 @@ const SecuritySchemeApiKey: React.FunctionComponent<OpenAPIV3.ApiKeySecuritySche
             <li>Parameter name: {api.name}</li>
             <li>In: {api.in}</li>
         </ul>
-        <span className="apid-m-text-break-all">{api.description}</span>
+        {
+            api.description &&
+            <span className="apid-m-text-break-all">
+                <ReactMarkdown>{api.description}</ReactMarkdown>
+            </span>
+        }
     </>;
 }


### PR DESCRIPTION
Different APIs use markdowns in descriptions.

This PR supports markdown in the following places:
* API descriptions
* Security Scheme descriptions
* Operation descriptions

### Advisor:

![image](https://github.com/RedHatInsights/api-documentation-frontend/assets/17099954/cf8a770a-eefc-4b74-956a-3f6fc71e1e2a)

### Export Service:
![image](https://github.com/RedHatInsights/api-documentation-frontend/assets/17099954/3f204edf-0a3e-4887-b477-670e95132f74)
