### PR TITLE
[RHCLOUD-28783] remove x-rh-identity and add Authorization header

### DIFF
--- a/packages/transform/src/main.ts
+++ b/packages/transform/src/main.ts
@@ -137,7 +137,7 @@ const cleanUnusedApiFiles = (foundApis: Array<BuildApi>, options: Options) => {
         ));
 }
 
-const replaceIdentityHeaders = (buildApis: Array<BuildApi>, options: Options) => {
+const replaceIdentityHeaders = (buildApis: Array<BuildApi>) => {
     buildApis.forEach(({ apiContent, app }) => {
         const { openapi } = apiContent;
         const { components } = openapi || {};
@@ -148,7 +148,6 @@ const replaceIdentityHeaders = (buildApis: Array<BuildApi>, options: Options) =>
         for (const [key, scheme] of Object.entries(securitySchemes)) {
             const typedScheme = scheme as OpenAPIV3.SecuritySchemeObject;
             if (typedScheme.type === "apiKey" && typedScheme.name.toLowerCase() === "x-rh-identity") {
-                console.log(`Replacing x-rh-identity for app: ${app.id}...`);
                 delete securitySchemes[key];
 
                 securitySchemes["Authorization"] = {
@@ -241,7 +240,7 @@ export const execute = async (options: Options) => {
 
     const buildApis: Array<BuildApi> = await downloadApis(discoveryContent.apis, options);
     cleanUnusedApiFiles(buildApis, options);
-    replaceIdentityHeaders(buildApis, options);
+    replaceIdentityHeaders(buildApis);
     fetchDocumentationContents(buildApis, options);
     writeApiContent(buildApis, options);
 

--- a/packages/transform/src/main.ts
+++ b/packages/transform/src/main.ts
@@ -137,6 +137,23 @@ const cleanUnusedApiFiles = (foundApis: Array<BuildApi>, options: Options) => {
         ));
 }
 
+const replaceIdentityHeaders = (buildApis: Array<BuildApi>, options: Options) => {
+    buildApis.forEach(api => {
+        // remove x-rh-identity from securitySchemes and add Authorization header
+        if (api.apiContent.openapi.components && api.apiContent.openapi.components.securitySchemes) {
+            if (api.apiContent.openapi.components.securitySchemes["x-rh-identity"]) {
+                delete api.apiContent.openapi.components.securitySchemes["x-rh-identity"];
+
+                api.apiContent.openapi.components.securitySchemes["Authorization"] = {
+                type: "apiKey",
+                in: "header",
+                name: "Authorization",
+                }
+            }
+        }
+    })
+}
+
 const writeApiContent = (foundApis: Array<BuildApi>, options: Options) => {
     foundApis.forEach(api => {
 
@@ -217,6 +234,7 @@ export const execute = async (options: Options) => {
 
     const buildApis: Array<BuildApi> = await downloadApis(discoveryContent.apis, options);
     cleanUnusedApiFiles(buildApis, options);
+    replaceIdentityHeaders(buildApis, options);
     fetchDocumentationContents(buildApis, options);
     writeApiContent(buildApis, options);
 

--- a/src/components/APIDoc/hooks/useGroupedOperations.ts
+++ b/src/components/APIDoc/hooks/useGroupedOperations.ts
@@ -40,18 +40,6 @@ const loadGrouped = (openapi: OpenAPIV3.Document, grouped: GroupedOperations) =>
     const defaultUrl = "https://www.example.com"
     let baseUrl = getServerURL(openapi.servers?.[0] || {url: defaultUrl});
 
-    // remove x-rh-identity from securitySchemes and add Authorization header
-    if (openapi.components && openapi.components.securitySchemes) {
-        delete openapi.components?.securitySchemes?.["x-rh-identity"];
-
-        console.log("SECURITY SCHEMES", openapi.components.securitySchemes)
-        openapi.components.securitySchemes["Authorization"] = {
-            type: "apiKey",
-            in: "header",
-            name: "Authorization",
-        }
-    }
-
     // check that baseUrl is a valid url
     try {
         new URL(baseUrl);

--- a/src/components/APIDoc/hooks/useGroupedOperations.ts
+++ b/src/components/APIDoc/hooks/useGroupedOperations.ts
@@ -40,6 +40,18 @@ const loadGrouped = (openapi: OpenAPIV3.Document, grouped: GroupedOperations) =>
     const defaultUrl = "https://www.example.com"
     let baseUrl = getServerURL(openapi.servers?.[0] || {url: defaultUrl});
 
+    // remove x-rh-identity from securitySchemes and add Authorization header
+    if (openapi.components && openapi.components.securitySchemes) {
+        delete openapi.components?.securitySchemes?.["x-rh-identity"];
+
+        console.log("SECURITY SCHEMES", openapi.components.securitySchemes)
+        openapi.components.securitySchemes["Authorization"] = {
+            type: "apiKey",
+            in: "header",
+            name: "Authorization",
+        }
+    }
+
     // check that baseUrl is a valid url
     try {
         new URL(baseUrl);

--- a/src/utils/Snippets.ts
+++ b/src/utils/Snippets.ts
@@ -12,10 +12,12 @@ const getHeaders = (inferredContentType: string, params: DeRefResponse<OpenAPIV3
     Object.values(document.components?.securitySchemes).forEach(s => {
       const scheme = deRef(s, document)
       if ("in" in scheme && scheme.in === "header") {
-        headers.push({name: scheme.name, value: scheme.type})
+        if (scheme.name === "Authorization") {
+          headers.push({name: scheme.name, value: "Bearer <token>"})
+        } else {
+          headers.push({name: scheme.name, value: scheme.name})
+        }
       }
-      // override default Authorization header value
-      headers.push({name: "Authorization", value: "Bearer <token>"})
     });
   }
   params.forEach(param => {

--- a/src/utils/Snippets.ts
+++ b/src/utils/Snippets.ts
@@ -15,7 +15,7 @@ const getHeaders = (inferredContentType: string, params: DeRefResponse<OpenAPIV3
         if (scheme.name === "Authorization") {
           headers.push({name: scheme.name, value: "Bearer <token>"})
         } else {
-          headers.push({name: scheme.name, value: scheme.name})
+          headers.push({name: scheme.name, value: scheme.type})
         }
       }
     });

--- a/src/utils/Snippets.ts
+++ b/src/utils/Snippets.ts
@@ -14,6 +14,8 @@ const getHeaders = (inferredContentType: string, params: DeRefResponse<OpenAPIV3
       if ("in" in scheme && scheme.in === "header") {
         headers.push({name: scheme.name, value: scheme.type})
       }
+      // override default Authorization header value
+      headers.push({name: "Authorization", value: "Bearer <token>"})
     });
   }
   params.forEach(param => {


### PR DESCRIPTION
[RHCLOUD-28783](https://issues.redhat.com/browse/RHCLOUD-28783)

- Replace `x-rh-identity` with `Authorization` header in all requests containing it.
- Override Authorization header value from `apiKey` to `Bearer <token>`