### PR TITLE
Fix Operation Heading and Sidebar

### DIFF
--- a/src/components/APIDoc/Operations/renderGroupedOperations.tsx
+++ b/src/components/APIDoc/Operations/renderGroupedOperations.tsx
@@ -27,7 +27,10 @@ export const renderGroupOperations = ({groupedOperations, openapi}: GroupedOpera
         ...(groupedOperations.groups.map(group => <StackItem key={`group-${group.id}`} id={getOperationGroupId(group.id)}>
             <TextContent className="pf-u-pb-lg">
                 <Text component={TextVariants.h3}>
-                    { group.name || group.description }
+                    { group.name }
+                </Text>
+                <Text component={TextVariants.p}>
+                    { group.description }
                 </Text>
             </TextContent>
             <Operations>{group

--- a/src/components/APIDoc/Operations/renderGroupedOperations.tsx
+++ b/src/components/APIDoc/Operations/renderGroupedOperations.tsx
@@ -27,7 +27,7 @@ export const renderGroupOperations = ({groupedOperations, openapi}: GroupedOpera
         ...(groupedOperations.groups.map(group => <StackItem key={`group-${group.id}`} id={getOperationGroupId(group.id)}>
             <TextContent className="pf-u-pb-lg">
                 <Text component={TextVariants.h3}>
-                    { group.description || group.name }
+                    { group.name || group.description }
                 </Text>
             </TextContent>
             <Operations>{group

--- a/src/components/SideBar/SidebarApiSections.tsx
+++ b/src/components/SideBar/SidebarApiSections.tsx
@@ -33,7 +33,7 @@ export const SidebarApiSections: FunctionComponent<SidebarApiSectionsProps> = ({
                         key={g.id}
                         href={`#${getOperationGroupId(g.id)}`}
                     >
-                        {g.description || g.name}
+                        {g.name || g.description}
                     </JumpLinksItem>
                 ));
 


### PR DESCRIPTION
[RHCLOUD-28596](https://issues.redhat.com/browse/RHCLOUD-28596)
- Use group name as heading instead of description
- Add description under heading
- Default to group name in sidebar (falls back to description if there is no name)

# Before
![before](https://github.com/RedHatInsights/api-documentation-frontend/assets/39098327/fddc5157-3f99-4560-91f4-301f94fec718)
# After
![after](https://github.com/RedHatInsights/api-documentation-frontend/assets/39098327/0fa21343-0b1c-48ee-8b7e-b57d3cc56160)
