### PR TITLE
Update search index contentType

### DIFF
--- a/packages/sitemap/src/collector.ts
+++ b/packages/sitemap/src/collector.ts
@@ -48,7 +48,7 @@ const getDocuments = (config: ReadonlyArray<Readonly<APIConfiguration>>, baseurl
 
         return {
             solr_command: "index",
-            contentType: "documentation",
+            contentType: "api_catalog",
             id: api.id,
             uri: `${baseurl}/api/${api.id}`,
             name: `${api.displayName} | API Catalog and Documentation`,


### PR DESCRIPTION
The Search SPA wants this value to be `api_catalog`.