### PR TITLE
Remove "Schemas" subtitle when there are no schemas

### DIFF
--- a/src/components/APIDoc/SchemaViewer.tsx
+++ b/src/components/APIDoc/SchemaViewer.tsx
@@ -10,6 +10,11 @@ interface SchemaViewerProps {
 
 export const SchemaViewer: React.FunctionComponent<SchemaViewerProps> = ({ document }) => {
     const schemas = document.components?.schemas;
+    const entries = schemas ? Object.entries(schemas) : undefined;
+
+    if (!entries || entries.length === 0) {
+        return null;
+    }
 
     return(
         <>


### PR DESCRIPTION
Ansible Automation Platform controller API doesn't have any schema in their openapi:

Before:
![image](https://github.com/RedHatInsights/api-documentation-frontend/assets/3845764/004d9def-7d5a-4aaa-93b4-541bdc0aa4ee)

After:
![image](https://github.com/RedHatInsights/api-documentation-frontend/assets/3845764/72a857e0-a742-4775-9831-1c311dfbfd24)
