### PR TITLE
Add subscriptions tag and add to Subscriptions API

### DIFF
--- a/packages/discovery/Discovery.yml
+++ b/packages/discovery/Discovery.yml
@@ -287,10 +287,11 @@ apis:
         apiType: openapi-v3
         icon: subscriptions
         tags:
+          - edge
           - inventories
           - openshift
-          - edge
           - rhel
+          - subscriptions
       - id: tasks
         name: Tasks
         description: API for managing and issuing Red Hat generated tasks on your infrastructure
@@ -573,6 +574,9 @@ tags:
   - id: spend-management
     name: Spend Management
     type: use-case
+  - id: subscriptions
+    name: Subscriptions
+    type: service
   - id: system-configuration
     name: System Configuration
     type: use-case

--- a/src/components/SideBar/SidebarTags.tsx
+++ b/src/components/SideBar/SidebarTags.tsx
@@ -22,7 +22,7 @@ const getTitle = (type: DisplayedTagsType) => {
         case 'use-case':
             return 'Use Case';
         case 'service':
-            return 'Saas Service';
+            return 'SaaS Service';
         case 'platform':
             return 'Red Hat Platform';
     }


### PR DESCRIPTION
Changes for [RHCLOUD-30616](https://issues.redhat.com/browse/RHCLOUD-30616) - Add "Subscriptions" as a tag; add it to Subscriptions API

1. Added `subscriptions` tag to the SaaS tag section 
2. Applied new tag to the Subscriptions API
3. Arranged service tags in alphabetical order 
4. Update "SaaS Service" title to use the most common acronym letter casing.  (`SaaS` instead of `Saas`)
