### PR TITLE
Move Subscriptions to be a use-case tag.

### DIFF
--- a/packages/discovery/Discovery.yml
+++ b/packages/discovery/Discovery.yml
@@ -576,7 +576,7 @@ tags:
     type: use-case
   - id: subscriptions
     name: Subscriptions
-    type: service
+    type: use-case
   - id: system-configuration
     name: System Configuration
     type: use-case


### PR DESCRIPTION
Correction to PR https://github.com/RedHatInsights/api-documentation-frontend/pull/276 to move the new "Subscriptions" tag under the "Use Case" section.

Jira: [RHCLOUD-30616](https://issues.redhat.com/browse/RHCLOUD-30616)
