### PR TITLE
URL Prefix change

### DIFF
--- a/src/components/APIDoc/hooks/useGroupedOperations.ts
+++ b/src/components/APIDoc/hooks/useGroupedOperations.ts
@@ -37,8 +37,13 @@ const getServerURL = (server: OpenAPIV3.ServerObject): string => {
 }
 
 const loadGrouped = (openapi: OpenAPIV3.Document, grouped: GroupedOperations) => {
-    const defaultUrl = "https://www.example.com"
+    const defaultUrl = "https://www.console.redhat.com"
     let baseUrl = getServerURL(openapi.servers?.[0] || {url: defaultUrl});
+    
+    // check to see if baseurl was loaded with a /, and try to append it to the defaultUrl
+    if(baseUrl.startsWith("/")) {
+        baseUrl = defaultUrl + baseUrl;
+    }
 
     // check that baseUrl is a valid url
     try {


### PR DESCRIPTION
The defaulturl is set to [example.com](http://example.com/) and the logic grabs the baseurl from the openapi spec and tries to create a valid URL. 

What I noticed was that some openapi specs have stuff like "/api/v1/example" as their base url which returns an error when trying to cast it as a URL in the code.

What I changed was that the defaulturl is now [console.redhat.com](http://console.redhat.com/) instead of [example.com](http://example.com/), and I added a check to see if the baseurl from the openapi spec starts with a "/". If it does then I append it to the end of the defaulturl and use that as the url in the example code box.

 If the openapi spec has a valid url already in it then the check is skipped and it works as expected

![Screenshot from 2024-04-22 19-41-41](https://github.com/RedHatInsights/api-documentation-frontend/assets/111240801/47fff51c-4864-49af-ac15-f08e50314b0b)


It is fixing this https://issues.redhat.com/browse/RHCLOUD-31601