### PR TITLE
Fix discovery: setting 'none' as the server_url for ansible-automation-controller to get around the discovery failures

### DIFF
--- a/packages/common/config/apis.ts
+++ b/packages/common/config/apis.ts
@@ -182,7 +182,7 @@ export const apiConfigurations: ReadonlyArray<Readonly<APIConfiguration>> = [
     icon: "AnsibleIcon",
     apiContentPath:
       "./apis/hcc-insights/ansible-automation-controller/content.json",
-    serverUrl: undefined,
+    serverUrl: "none",
     getApiContent: () =>
       import(
         "./apis/hcc-insights/ansible-automation-controller/content.json"

--- a/packages/discovery/Discovery.yml
+++ b/packages/discovery/Discovery.yml
@@ -18,6 +18,7 @@ apis:
         name: Ansible automation controller API
         description: Define, operate, scale, and delegate automation across your enterprise
         url: https://raw.githubusercontent.com/ansible/aap-docs/2.4/controller-api/_swagger/ansible-controller-api.json
+        serverUrl: none
         apiType: openapi-v3
         icon: ansible
         tags:


### PR DESCRIPTION
Fix discovery: setting 'none' as the server_url for ansible-automation-controller to get around the discovery failures

- updated the `Discovery.yml` file.
- ran `npm run discovery:build && npm run discovery:start -- --skip-api-fetch` to update `packages/common/config/apis.ts`