### PR TITLE
Fix missing schema definitions

### DIFF
--- a/src/components/APIDoc/SchemaDataView.tsx
+++ b/src/components/APIDoc/SchemaDataView.tsx
@@ -142,15 +142,6 @@ const findConditionKey = (value: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObj
 }
 
 const getTreeViewData = (schemaName: string, schema: DeRefResponse<OpenAPIV3.ArraySchemaObject | OpenAPIV3.NonArraySchemaObject>, document: OpenAPIV3.Document) => {
-  if (schema.type && !schema.properties) {
-    return [{ name: <PropertyView
-          propSchema={schema}
-          propName={schema.deRefData ? schema.deRefData.name : ""}
-          propertyType={<SchemaType schema={schema} document={document}/>}
-          required={false}/>
-    }] as TreeViewDataItem[]
-  }
-
   const conditionalSchema = findConditionKey(schema)
   if (conditionalSchema) {
     const {schemaKey, schemaVal} = conditionalSchema
@@ -158,7 +149,16 @@ const getTreeViewData = (schemaName: string, schema: DeRefResponse<OpenAPIV3.Arr
   }
 
   if (!schema.properties) {
-    return [{name: "schema undefined"}] as TreeViewDataItem[]
+    return [{ 
+      name: schema.type ? (
+        <PropertyView 
+          propSchema={schema}
+          propName={schema.deRefData?.name ?? ""}
+          propertyType={<SchemaType schema={schema} document={document}/>}
+          required={false}
+        />
+      ) : "schema undefined"
+    }] as TreeViewDataItem[]
   }
 
   const schemaKeyValArray = Object.entries(schema.properties)


### PR DESCRIPTION
Fixes [RHCLOUD-29608](https://issues.redhat.com/browse/RHCLOUD-29608)

Updated the `getTreeViewData` logic to check if there is a conditional schema before just displaying `PropertyView`

Before:
![image](https://github.com/user-attachments/assets/38eeaa5f-83ec-44f8-a511-b21513a5d33b)

Now:
![image](https://github.com/user-attachments/assets/a0b47e04-a5fd-4d96-8fbc-2a9319c3342b)
