### PR TITLE
add build-tools submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build-tools"]
+	path = build-tools
+	url = https://github.com/RedHatInsights/insights-frontend-builder-common.git


### PR DESCRIPTION
In order to use the new build script system the build-tools submodule is required to use the shared Dockerfile