### PR TITLE
create sitemap during build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY public ./public
 COPY packages ./packages
 
 RUN npm i
-RUN npm run sitemap
+RUN SITEMAP_BASE_URL=https://developers.redhat.com/api-catalog npm run sitemap
 RUN npm run build
 
 FROM registry.access.redhat.com/ubi9/nginx-124

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY public ./public
 COPY packages ./packages
 
 RUN npm i
+RUN npm run sitemap
 RUN npm run build
 
 FROM registry.access.redhat.com/ubi9/nginx-124


### PR DESCRIPTION
An error was discovered in our SPA that resulted in a 404 for our `sitemap.yml` file. The gitlab ci build system included an `npm` command that builds the `sitemap.yml` [file](https://github.com/RedHatInsights/api-documentation-frontend/pull/429). 

This change adds the `npm run sitemap` directly to the Dockerfile. 