### PR TITLE
Allow serverUrl to be undefined

### DIFF
--- a/packages/common/types.ts
+++ b/packages/common/types.ts
@@ -16,7 +16,7 @@ export interface APIConfiguration {
     icon:  keyof typeof APIConfigurationIcons;
     description: string;
     apiContentPath: string;
-    serverUrl: string;
+    serverUrl: string | undefined;
     getApiContent: () => Promise<APIContent>;
     tags: ReadonlyArray<Readonly<APILabel>>;
 }


### PR DESCRIPTION
When is undefined (or an invalid url) the default url is used. (or tge base url in the openapi file if it exists).

This should fix #490 