### PR TITLE
HMS-5777: remove edge management from api docs

### DIFF
--- a/packages/common/config/apis.ts
+++ b/packages/common/config/apis.ts
@@ -532,19 +532,6 @@ export const apiConfigurations: ReadonlyArray<Readonly<APIConfiguration>> = [
     ],
   },
   {
-    id: "edge",
-    displayName: "RHEL for Edge",
-    description: "RHEL for Edge API",
-    icon: "EdgeIcon",
-    apiContentPath: "./apis/hcc-insights/edge/content.json",
-    serverUrl: "https://console.redhat.com",
-    getApiContent: () =>
-      import(
-        "./apis/hcc-insights/edge/content.json"
-      ) as unknown as Promise<APIContent>,
-    tags: [apiLabelsMap["edge"], apiLabelsMap["rhel"]],
-  },
-  {
     id: "rbac",
     displayName: "Role-based Access Control",
     description: "The API for Role Based Access Control",

--- a/packages/discovery/Discovery.yml
+++ b/packages/discovery/Discovery.yml
@@ -259,16 +259,6 @@ apis:
           - deploy
           - insights
           - rhel
-      - id: edge
-        name: RHEL for Edge
-        description: RHEL for Edge API
-        url: https://console.redhat.com/api/edge/v1/openapi.json
-        serverUrl: https://console.redhat.com
-        apiType: openapi-v3
-        icon: edge
-        tags:
-          - edge
-          - rhel
       - id: rbac
         name: Role-based Access Control
         description: The API for Role Based Access Control


### PR DESCRIPTION
Edge Management is decommissioned. Removing from API docs.

Fixes: HMS-5777