### PR TITLE
Add write permissions to sync discovery workflow

### DIFF
--- a/.github/workflows/sync-discovery.yml
+++ b/.github/workflows/sync-discovery.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `contents: write` and `pull-requests: write` permissions to the sync discovery workflow
- Fixes ref creation failure (`Reference update failed`) when `create-pull-request` attempts to push the sync branch

## Context
The sync discovery workflow has been failing since repo rules requiring signed commits were enforced. The previous PR added `sign-commits: true` and upgraded to `create-pull-request@v8`. This PR adds the explicit permissions block needed for the workflow to create branch refs and PRs via the GitHub API.

## Test plan
- [ ] Verify the sync discovery workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)