### PR TITLE
fix: pin GitHub Actions to commit SHAs for sha_pinning_required policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Get commit hash
         run: |
@@ -71,7 +71,7 @@ jobs:
           exit 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24.x'
           cache: 'npm'

--- a/.github/workflows/sync-discovery.yml
+++ b/.github/workflows/sync-discovery.yml
@@ -22,7 +22,7 @@ jobs:
         node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         token: ${{ secrets.GH_BOT_TOKEN }}
     - name: Import GPG key
@@ -34,7 +34,7 @@ jobs:
         git config tag.gpgsign true
         git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ secrets.BOT_EMAIL }}" | awk -F: '/^sec:/ {print $5; exit}')
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
       run: npm run discovery
     - name: Create Pull Request
       id: cpr
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
       with:
         token: ${{ secrets.GH_BOT_TOKEN }}
         sign-commits: true

--- a/.github/workflows/validate-discovery-apps.yml
+++ b/.github/workflows/validate-discovery-apps.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/validate-discovery-file.yml
+++ b/.github/workflows/validate-discovery-file.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
## Summary
- All workflows have been failing with `startup_failure` since ~Aug 13 because the org enforces `sha_pinning_required: true`, which rejects tag-based action references (`@v7`, `@v8`)
- Pins all 8 action references across 4 workflow files to their full commit SHAs:
  - `actions/checkout@v7` → `3d3c42e5aac5ba805825da76410c181273ba90b1`
  - `actions/setup-node@v7` → `820762786026740c76f36085b0efc47a31fe5020`
  - `peter-evans/create-pull-request@v8` → `5f6978faf089d4d20b00c7766989d076bb2fc7f1`

## Additional action required
`peter-evans/create-pull-request` is **not** in the repo's allowed actions list. It must be added under **Settings → Actions → General → Allow select actions** for the sync-discovery workflow to fully work.

## Test plan
- [ ] Verify workflows no longer fail with `startup_failure` after merge
- [x] Add `peter-evans/create-pull-request@*` to repo allowed actions
- [ ] Confirm the nightly sync-discovery scheduled run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)