### PR TITLE
fix: remove unused GPG import step from sync-discovery workflow

### DIFF
--- a/.github/workflows/sync-discovery.yml
+++ b/.github/workflows/sync-discovery.yml
@@ -25,14 +25,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         token: ${{ secrets.GH_BOT_TOKEN }}
-    - name: Import GPG key
-      run: |
-        echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 -d | gpg --batch --import
-        git config user.name "${{ secrets.BOT_NAME }}"
-        git config user.email "${{ secrets.BOT_EMAIL }}"
-        git config commit.gpgsign true
-        git config tag.gpgsign true
-        git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ secrets.BOT_EMAIL }}" | awk -F: '/^sec:/ {print $5; exit}')
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:


### PR DESCRIPTION
## Summary
- Removes the "Import GPG key" step from the sync-discovery workflow
- This step was failing with `base64: invalid input` and is not needed — `peter-evans/create-pull-request` with `sign-commits: true` signs commits via the GitHub API, not local git
- nacho-bot still authors the PR and commits via `GH_BOT_TOKEN` and the `author` field

## Test plan
- [ ] Merge and verify the sync-discovery workflow passes on the next push or scheduled run
- [ ] Confirm the PR created by sync-discovery still shows commits as "Verified"

🤖 Generated with [Claude Code](https://claude.com/claude-code)