### PR TITLE
fix: use PR-based approach for sync-discovery workflow

### DIFF
--- a/.github/workflows/sync-discovery.yml
+++ b/.github/workflows/sync-discovery.yml
@@ -5,6 +5,7 @@
 name: Sync discovery
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
   push:
@@ -12,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build:
@@ -40,13 +42,29 @@ jobs:
     - run: npm ci
     - id: discovery
       run: npm run discovery
-    - name: Push sync changes
+    - name: Create sync PR
+      env:
+        GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
       run: |
         if git diff --quiet; then
           echo "No changes detected. Skipping."
           exit 0
         fi
 
+        BRANCH="sync-discovery/patch"
+
         git add packages/common/config/
-        git commit -m "Syncing API [skip ci]"
-        git push
+        git commit -m "Syncing API discovery"
+        git push --force origin "HEAD:refs/heads/$BRANCH"
+
+        EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+        if [ -z "$EXISTING_PR" ]; then
+          gh pr create \
+            --head "$BRANCH" \
+            --title "Syncing API discovery" \
+            --body "Automated sync of API discovery data." \
+            --label "automated"
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+        fi
+
+        gh pr merge "$EXISTING_PR" --auto --squash --delete-branch


### PR DESCRIPTION
## Summary
- Direct push to main is blocked by branch protection (requires PRs + Konflux status checks)
- Replaces direct push with: push to `sync-discovery/patch` branch → create PR → auto-merge (squash)
- Adds `workflow_dispatch` trigger for manual testing
- Uses GPG-signed commits via local git, not GitHub API

## Test plan
- [ ] Manually trigger the workflow from Actions tab on this branch
- [ ] Verify GPG signing, branch push, and PR creation work end-to-end
- [ ] Verify auto-merge enables successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)