### PR TITLE
fix: remove non-existent label from sync-discovery PR creation

### DIFF
--- a/.github/workflows/sync-discovery.yml
+++ b/.github/workflows/sync-discovery.yml
@@ -62,8 +62,7 @@ jobs:
           gh pr create \
             --head "$BRANCH" \
             --title "Syncing API discovery" \
-            --body "Automated sync of API discovery data." \
-            --label "automated"
+            --body "Automated sync of API discovery data."
           EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
         fi
 


### PR DESCRIPTION
## Summary
- The `automated` label doesn't exist in the repo, causing `gh pr create` to fail
- Removes the `--label` flag so the PR creation succeeds

## Context
The previous run (32177964183) got all the way through GPG signing, committing, and pushing the branch — it only failed on `could not add label: 'automated' not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)