### PR TITLE
Support YAML OpenAPI specs in discovery transform

### DIFF
--- a/packages/transform/src/main.ts
+++ b/packages/transform/src/main.ts
@@ -90,7 +90,7 @@ const downloadApis = (groups: Array<Group>, options: Options): Promise<Array<Bui
                 let error: string | undefined = undefined;
                 try {
                     let openApiContent = await getOpenAPIContent(getDiscoveryPath(options), app, group.id, options);
-                    content = JSON.parse(openApiContent);
+                    content = parse(openApiContent);
 
                     // Validate remotely fetched content for dangerous patterns
                     if (app.url && !app.useLocalFile && !options.skipApiFetch) {


### PR DESCRIPTION
## Summary

- The transform pipeline's content-type validation (`validation.ts`) already accepted YAML responses (`application/yaml`, `text/yaml`, etc.), but `main.ts` used `JSON.parse()` to parse fetched specs — which fails on YAML content
- Switch to the `yaml` package's `parse()` (already imported in the file) which handles both JSON and YAML since YAML is a superset of JSON
- This unblocks APIs that serve YAML OpenAPI specs (e.g. automation-orchestrator added in #911, which was silently skipped with `No number after minus sign in JSON`)

## Test plan

- [ ] `npm run discovery:build` passes
- [ ] `npm run lint` passes
- [ ] Existing JSON-based API specs still parse correctly (YAML parser handles JSON natively)
- [ ] After merge, the nightly sync should pick up automation-orchestrator successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)