### PR TITLE
fix: PF6 page layout and code editor dark theme

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -6,10 +6,18 @@
   --pfe-theme--color--ui-accent: #e00;
 }
 
-.apid-c-page-landingpage, .apid-c-page-apipage {
+.pf-v6-c-page.apid-c-page-landingpage,
+.pf-v6-c-page.apid-c-page-apipage {
   --pf-v6-c-page__main--ZIndex: 1;
-    max-width: 1500px; //remove before developers.redhat.com classes
-    margin: auto;
+  --pf-v6-c-page--inset: 0;
+  grid-template-columns: 1fr;
+  grid-template-areas: "header" "main";
+  .pf-v6-c-page__main-container {
+    border-radius: 0;
+    border-width: 0;
+    box-shadow: none;
+    max-height: 100%;
+  }
  }
 
 .apid-c-page-landingpage {

--- a/src/components/APIDoc/CodeSamples.tsx
+++ b/src/components/APIDoc/CodeSamples.tsx
@@ -17,6 +17,7 @@ export const CodeSamples: React.FunctionComponent<CodeSampleProps> = ({ codesnip
 
   return (
     <CodeEditor
+      isDarkTheme={true}
       isLineNumbersVisible={false}
       isReadOnly={true}
       isCopyEnabled={true}


### PR DESCRIPTION
## Summary
- Fix PF6 Page component reserving a sidebar grid column at large viewports, pushing content to the right. Override with single-column grid and reset glass design system insets since this app is embedded in the Red Hat Developer chrome.
- Restore `isDarkTheme` prop on CodeEditor that was dropped during PF6 migration, making code sample text invisible.
- Remove stale `max-width: 1500px` constraint on page layout.

## References
https://redhat.atlassian.net/browse/RHCLOUD-50706

## Test plan
- [x] Verify landing page fills full viewport width with no empty left column
- [x] Verify API detail page also fills full width
- [x] Navigate into an API and confirm code samples display text with dark theme
- [ ] Test at different viewport widths (especially >1200px where the PF6 sidebar grid activates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)