### PR TITLE
fix: restrict GITHUB_TOKEN scope in validate workflows

### DIFF
--- a/.github/workflows/validate-discovery-apps.yml
+++ b/.github/workflows/validate-discovery-apps.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/validate-discovery-file.yml
+++ b/.github/workflows/validate-discovery-file.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'packages/discovery/**'
 
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to `validate-discovery-file.yml` and `validate-discovery-apps.yml` workflows
- Follows least-privilege principle per OpenSSF Scorecard Token-Permissions guidance
- `sync-discovery.yml` already had the correct permissions block

Resolves: https://redhat.atlassian.net/browse/RHCLOUD-50060

## Test plan
- [ ] Verify `validate-discovery-file` workflow triggers correctly on PRs modifying `packages/discovery/**`
- [ ] Verify `validate-discovery-apps` workflow runs on its daily cron schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)