### PR TITLE
fix: resolve 404 errors for favicons and shared lib assets

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,16 @@
 import type { NextConfig } from 'next';
 import MonacoWebpackPlugin from 'monaco-editor-webpack-plugin';
 
+const basePath = process.env.DEV === 'true' ? '' : '/api-catalog';
+
 const nextConfig: NextConfig = {
   /* config options here */
   output: 'export',
   images: {
     unoptimized: true,
+  },
+  env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
   },
   ...(process.env.DEV === 'true'
     ? {

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,7 +46,7 @@ http {
     } 
 
     # nested routes 
-    rewrite ^/api-catalog/api/(.*)$ /api/$1.html last;
+    rewrite ^/api-catalog/api/([^.]+)$ /api/$1.html last;
     # other assets like JS and CSS
     rewrite ^/api-catalog(.+)$ $1 last;
     # index route

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,7 @@ http {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://developers.redhat.com https://www.redhat.com https://cdn.pendo.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://developers.redhat.com https://www.redhat.com; font-src 'self' https://developers.redhat.com; connect-src 'self' https://cdn.pendo.io https://app.pendo.io https://www.redhat.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://developers.redhat.com https://www.redhat.com https://cdn.pendo.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://developers.redhat.com https://www.redhat.com https://access.redhat.com; font-src 'self' https://developers.redhat.com; connect-src 'self' https://cdn.pendo.io https://app.pendo.io https://www.redhat.com https://cdnjs.cloudflare.com https://id.redhat.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
     location / {
       ssi on;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -111,14 +111,17 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head suppressHydrationWarning={true}>
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicon2023-32x32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicon2023-16x16.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href={`${process.env.NEXT_PUBLIC_BASE_PATH}/favicon2023-32x32.png`} />
+        <link rel="icon" type="image/png" sizes="16x16" href={`${process.env.NEXT_PUBLIC_BASE_PATH}/favicon2023-16x16.png`} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
         <script suppressHydrationWarning={true} dangerouslySetInnerHTML={{ __html: headerPatch }}></script>
         <script suppressHydrationWarning={true} dangerouslySetInnerHTML={{ __html: analyticsInclude }}></script>
         <script suppressHydrationWarning={true} dangerouslySetInnerHTML={{ __html: pendoInclude }}></script>
-        <script type="module" src="/modules/contrib/red_hat_shared_libs/dist/rhds-elements/modules/rh-footer/rh-footer.js?v=2.1.1"></script>
+        <script
+          type="module"
+          src="https://developers.redhat.com/modules/contrib/red_hat_shared_libs/dist/rhds-elements/modules/rh-footer/rh-footer.js?v=2.1.1"
+        ></script>
       </head>
       <body>
         <div className="rhd-m-max-width-xl">
@@ -143,8 +146,14 @@ export default function RootLayout({
             integrity="sha384-HxnMqvBKlkVSmShpzRmR5hazrKXrtEVhT8YU2MXRjOP577yZ+RvsyzVRCB6f9o17"
             crossOrigin="anonymous"
           ></script>
-          <link rel="stylesheet" href="/modules/contrib/red_hat_shared_libs/dist/@cpelements/pfe-navigation/dist/pfe-navigation--lightdom.css" />
-          <link rel="stylesheet" href="/modules/contrib/red_hat_shared_libs/dist/@patternfly/pfe-cta/dist/pfe-cta--lightdom.min.css" />
+          <link
+            rel="stylesheet"
+            href="https://developers.redhat.com/modules/contrib/red_hat_shared_libs/dist/@cpelements/pfe-navigation/dist/pfe-navigation--lightdom.css"
+          />
+          <link
+            rel="stylesheet"
+            href="https://developers.redhat.com/modules/contrib/red_hat_shared_libs/dist/@patternfly/pfe-cta/dist/pfe-cta--lightdom.min.css"
+          />
           <script src="https://developers.redhat.com/modules/contrib/red_hat_shared_libs/dist/@patternfly/pfelement/dist/pfelement.umd.min.js?rrg73h"></script>
           <script src="https://developers.redhat.com/modules/contrib/red_hat_shared_libs/dist/%40cpelements/pfe-navigation/dist/pfe-navigation.umd.min.js?rrg73h"></script>
           <script src="https://developers.redhat.com/modules/contrib/red_hat_shared_libs/dist/%40patternfly/pfe-cta/dist/pfe-cta.umd.min.js?rrg73h"></script>


### PR DESCRIPTION
## Summary
- **Favicon `<link>` tags** now use the Next.js `basePath` so they resolve to `/api-catalog/favicon2023-*.png` in production instead of the domain root
- **rh-footer.js** script and two CSS `<link>` tags changed from root-relative `/modules/...` paths to absolute `https://developers.redhat.com/modules/...` URLs, matching the pattern of the other shared lib scripts already in the file
- **nginx rewrite rule** changed from `(.*)` to `([^.]+)` so `.txt` RSC payload requests (e.g. `/api-catalog/api/insights-advisor.txt`) are no longer rewritten to `/api/insights-advisor.txt.html` (404) — they now correctly resolve to `/api/insights-advisor.txt`
- **CSP header** updated to allow `access.redhat.com` images (SVG icons from SSI header), `cdnjs.cloudflare.com` connect (source maps), and `id.redhat.com` connect (dpal.js auth)
- Exposed `basePath` as `NEXT_PUBLIC_BASE_PATH` env var in `next.config.ts`

Resolves: [RHCLOUD-45280](https://redhat.atlassian.net/browse/RHCLOUD-45280)

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] Inspect `out/index.html` — favicon hrefs include `/api-catalog/` prefix
- [ ] Inspect `out/index.html` — rh-footer.js and CSS links use absolute `https://developers.redhat.com/` URLs
- [ ] Deploy to staging and verify:
  - No 404s for favicons in browser Network tab
  - No 404s for `.txt` RSC payloads when navigating between pages
  - Shared lib scripts/CSS load correctly
  - No CSP violations for `access.redhat.com` images, `cdnjs.cloudflare.com`, or `id.redhat.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-45280]: https://redhat.atlassian.net/browse/RHCLOUD-45280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ